### PR TITLE
feat: add professor and coordinator registration API (Resolves #10)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/ProfessorController.java
+++ b/backend/src/main/java/com/spms/backend/controller/ProfessorController.java
@@ -1,0 +1,31 @@
+package com.spms.backend.controller;
+
+import com.spms.backend.dto.request.ProfessorRegisterRequest;
+import com.spms.backend.dto.response.ProfessorRegisterResponse;
+import com.spms.backend.service.ProfessorRegistrationService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/professors")
+public class ProfessorController {
+
+    private final ProfessorRegistrationService professorRegistrationService;
+
+    public ProfessorController(ProfessorRegistrationService professorRegistrationService) {
+        this.professorRegistrationService = professorRegistrationService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<ProfessorRegisterResponse> registerProfessor(
+            @Valid @RequestBody ProfessorRegisterRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(professorRegistrationService.registerProfessor(request));
+    }
+}

--- a/backend/src/main/java/com/spms/backend/dto/request/ProfessorRegisterRequest.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/ProfessorRegisterRequest.java
@@ -1,0 +1,17 @@
+package com.spms.backend.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ProfessorRegisterRequest(
+        @NotBlank(message = "fullName is required.")
+        String fullName,
+        @NotBlank(message = "email is required.")
+        @Email(message = "email must be a valid email address.")
+        String email,
+        @NotBlank(message = "password is required.")
+        String password,
+        @NotBlank(message = "role is required.")
+        String role
+) {
+}

--- a/backend/src/main/java/com/spms/backend/dto/response/ProfessorRegisterResponse.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/ProfessorRegisterResponse.java
@@ -1,0 +1,8 @@
+package com.spms.backend.dto.response;
+
+public record ProfessorRegisterResponse(
+        String message,
+        Long userId,
+        String role
+) {
+}

--- a/backend/src/main/java/com/spms/backend/model/User.java
+++ b/backend/src/main/java/com/spms/backend/model/User.java
@@ -7,6 +7,7 @@ public class User {
     private Long userId;
     private String fullName;
     private String email;
+    private String passwordHash;
     private String studentId;
     private String githubUsername;
     private String role;
@@ -19,6 +20,7 @@ public class User {
         this.userId = other.userId;
         this.fullName = other.fullName;
         this.email = other.email;
+        this.passwordHash = other.passwordHash;
         this.studentId = other.studentId;
         this.githubUsername = other.githubUsername;
         this.role = other.role;
@@ -47,6 +49,14 @@ public class User {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
     }
 
     public String getStudentId() {

--- a/backend/src/main/java/com/spms/backend/repository/SupabaseUserRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/SupabaseUserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import java.time.Instant;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -24,9 +25,25 @@ public class SupabaseUserRepository implements UserRepository {
      * and credentials are finalized by the team.
      */
     private final Map<Long, User> usersById = new ConcurrentHashMap<>();
+    private final Map<String, Long> emailIndex = new ConcurrentHashMap<>();
     private final Map<String, Long> studentIdIndex = new ConcurrentHashMap<>();
     private final Map<String, Long> githubUsernameIndex = new ConcurrentHashMap<>();
     private final AtomicLong idSequence = new AtomicLong(1L);
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        String normalizedEmail = normalizeEmail(email);
+        if (normalizedEmail == null) {
+            return Optional.empty();
+        }
+
+        Long userId = emailIndex.get(normalizedEmail);
+        if (userId == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(usersById.get(userId)).map(User::new);
+    }
 
     @Override
     public Optional<User> findByStudentId(String studentId) {
@@ -71,8 +88,9 @@ public class SupabaseUserRepository implements UserRepository {
         } else {
             User existingUser = usersById.get(userToStore.getUserId());
             if (existingUser != null) {
-                removeIndex(studentIdIndex, existingUser.getStudentId());
-                removeIndex(githubUsernameIndex, existingUser.getGithubUsername());
+                removeEmailIndex(existingUser.getEmail());
+                removeStudentIdIndex(existingUser.getStudentId());
+                removeGithubUsernameIndex(existingUser.getGithubUsername());
                 if (userToStore.getCreatedAt() == null) {
                     userToStore.setCreatedAt(existingUser.getCreatedAt());
                 }
@@ -82,29 +100,59 @@ public class SupabaseUserRepository implements UserRepository {
         }
 
         usersById.put(userToStore.getUserId(), new User(userToStore));
-        putIndex(studentIdIndex, userToStore.getStudentId(), userToStore.getUserId());
-        putIndex(githubUsernameIndex, userToStore.getGithubUsername(), userToStore.getUserId());
+        putEmailIndex(userToStore.getEmail(), userToStore.getUserId());
+        putStudentIdIndex(userToStore.getStudentId(), userToStore.getUserId());
+        putGithubUsernameIndex(userToStore.getGithubUsername(), userToStore.getUserId());
         return new User(userToStore);
     }
 
-    private void putIndex(Map<String, Long> index, String rawValue, Long userId) {
-        String normalizedValue = index == githubUsernameIndex
-                ? normalizeGithubUsername(rawValue)
-                : normalizeStudentId(rawValue);
-
+    private void putEmailIndex(String rawValue, Long userId) {
+        String normalizedValue = normalizeEmail(rawValue);
         if (normalizedValue != null) {
-            index.put(normalizedValue, userId);
+            emailIndex.put(normalizedValue, userId);
         }
     }
 
-    private void removeIndex(Map<String, Long> index, String rawValue) {
-        String normalizedValue = index == githubUsernameIndex
-                ? normalizeGithubUsername(rawValue)
-                : normalizeStudentId(rawValue);
-
+    private void putStudentIdIndex(String rawValue, Long userId) {
+        String normalizedValue = normalizeStudentId(rawValue);
         if (normalizedValue != null) {
-            index.remove(normalizedValue);
+            studentIdIndex.put(normalizedValue, userId);
         }
+    }
+
+    private void putGithubUsernameIndex(String rawValue, Long userId) {
+        String normalizedValue = normalizeGithubUsername(rawValue);
+        if (normalizedValue != null) {
+            githubUsernameIndex.put(normalizedValue, userId);
+        }
+    }
+
+    private void removeEmailIndex(String rawValue) {
+        String normalizedValue = normalizeEmail(rawValue);
+        if (normalizedValue != null) {
+            emailIndex.remove(normalizedValue);
+        }
+    }
+
+    private void removeStudentIdIndex(String rawValue) {
+        String normalizedValue = normalizeStudentId(rawValue);
+        if (normalizedValue != null) {
+            studentIdIndex.remove(normalizedValue);
+        }
+    }
+
+    private void removeGithubUsernameIndex(String rawValue) {
+        String normalizedValue = normalizeGithubUsername(rawValue);
+        if (normalizedValue != null) {
+            githubUsernameIndex.remove(normalizedValue);
+        }
+    }
+
+    private String normalizeEmail(String email) {
+        if (!StringUtils.hasText(email)) {
+            return null;
+        }
+        return email.trim().toLowerCase(Locale.ROOT);
     }
 
     private String normalizeStudentId(String studentId) {
@@ -118,6 +166,6 @@ public class SupabaseUserRepository implements UserRepository {
         if (!StringUtils.hasText(githubUsername)) {
             return null;
         }
-        return githubUsername.trim().toLowerCase();
+        return githubUsername.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/backend/src/main/java/com/spms/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/UserRepository.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 
 public interface UserRepository {
 
+    Optional<User> findByEmail(String email);
+
     Optional<User> findByStudentId(String studentId);
 
     Optional<User> findByGithubUsername(String githubUsername);

--- a/backend/src/main/java/com/spms/backend/service/ProfessorRegistrationService.java
+++ b/backend/src/main/java/com/spms/backend/service/ProfessorRegistrationService.java
@@ -1,0 +1,126 @@
+package com.spms.backend.service;
+
+import com.spms.backend.dto.request.ProfessorRegisterRequest;
+import com.spms.backend.dto.response.ProfessorRegisterResponse;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.exception.DuplicateUserException;
+import com.spms.backend.model.User;
+import com.spms.backend.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Locale;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
+@Service
+public class ProfessorRegistrationService {
+
+    private static final String PROFESSOR_ROLE = "professor";
+    private static final String COORDINATOR_ROLE = "coordinator";
+    private static final String HASH_ALGORITHM = "PBKDF2WithHmacSHA256";
+    private static final int HASH_ITERATIONS = 65_536;
+    private static final int HASH_KEY_LENGTH = 256;
+    private static final int SALT_LENGTH = 16;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private final UserRepository userRepository;
+
+    public ProfessorRegistrationService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public ProfessorRegisterResponse registerProfessor(ProfessorRegisterRequest request) {
+        String fullName = requireText(request.fullName(), "fullName is required.");
+        String email = normalizeEmail(request.email());
+        String password = requirePassword(request.password());
+        String role = validateRole(request.role());
+
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new DuplicateUserException("A user already exists for the given email.");
+        }
+
+        User savedUser = userRepository.save(buildProfessorUser(fullName, email, password, role));
+        return new ProfessorRegisterResponse(
+                "Professor registered successfully.",
+                savedUser.getUserId(),
+                savedUser.getRole()
+        );
+    }
+
+    private User buildProfessorUser(String fullName, String email, String password, String role) {
+        User user = new User();
+        user.setFullName(fullName);
+        user.setEmail(email);
+        user.setPasswordHash(hashPassword(password));
+        user.setRole(role);
+        user.setCreatedAt(Instant.now());
+        return user;
+    }
+
+    boolean matchesPassword(String rawPassword, String passwordHash) {
+        String[] parts = passwordHash.split("\\$");
+        if (parts.length != 4 || !"pbkdf2".equals(parts[0])) {
+            return false;
+        }
+
+        int iterations = Integer.parseInt(parts[1]);
+        byte[] salt = Base64.getDecoder().decode(parts[2]);
+        byte[] expectedHash = Base64.getDecoder().decode(parts[3]);
+        byte[] candidateHash = hash(rawPassword, salt, iterations);
+        return MessageDigest.isEqual(expectedHash, candidateHash);
+    }
+
+    private String requireText(String value, String message) {
+        if (!StringUtils.hasText(value)) {
+            throw new BadRequestException(message);
+        }
+        return value.trim();
+    }
+
+    private String requirePassword(String value) {
+        if (!StringUtils.hasText(value)) {
+            throw new BadRequestException("password is required.");
+        }
+        return value;
+    }
+
+    private String normalizeEmail(String value) {
+        return requireText(value, "email is required.").toLowerCase(Locale.ROOT);
+    }
+
+    private String validateRole(String value) {
+        String role = requireText(value, "role is required.");
+        if (!PROFESSOR_ROLE.equals(role) && !COORDINATOR_ROLE.equals(role)) {
+            throw new BadRequestException("role must be either professor or coordinator.");
+        }
+        return role;
+    }
+
+    private String hashPassword(String password) {
+        byte[] salt = new byte[SALT_LENGTH];
+        SECURE_RANDOM.nextBytes(salt);
+        byte[] hash = hash(password, salt, HASH_ITERATIONS);
+        return "pbkdf2$" + HASH_ITERATIONS + "$"
+                + Base64.getEncoder().encodeToString(salt) + "$"
+                + Base64.getEncoder().encodeToString(hash);
+    }
+
+    private byte[] hash(String password, byte[] salt, int iterations) {
+        PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, iterations, HASH_KEY_LENGTH);
+        try {
+            SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance(HASH_ALGORITHM);
+            return secretKeyFactory.generateSecret(spec).getEncoded();
+        } catch (GeneralSecurityException exception) {
+            throw new IllegalStateException("Failed to hash password.", exception);
+        } finally {
+            spec.clearPassword();
+        }
+    }
+}

--- a/backend/src/test/java/com/spms/backend/controller/ProfessorControllerTest.java
+++ b/backend/src/test/java/com/spms/backend/controller/ProfessorControllerTest.java
@@ -1,0 +1,120 @@
+package com.spms.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spms.backend.dto.request.ProfessorRegisterRequest;
+import com.spms.backend.exception.GlobalExceptionHandler;
+import com.spms.backend.repository.SupabaseUserRepository;
+import com.spms.backend.service.ProfessorRegistrationService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class ProfessorControllerTest {
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+        validator.afterPropertiesSet();
+
+        ProfessorController professorController = new ProfessorController(
+                new ProfessorRegistrationService(new SupabaseUserRepository())
+        );
+
+        mockMvc = MockMvcBuilders.standaloneSetup(professorController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setValidator(validator)
+                .build();
+    }
+
+    @Test
+    void registerProfessorReturns201WhenRequestIsValid() throws Exception {
+        ProfessorRegisterRequest request = new ProfessorRegisterRequest(
+                "Dr. Jane Doe",
+                "jane.doe@university.edu",
+                "SecurePass123!",
+                "professor"
+        );
+
+        mockMvc.perform(post("/api/v1/professors/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.message").value("Professor registered successfully."))
+                .andExpect(jsonPath("$.userId").value(1))
+                .andExpect(jsonPath("$.role").value("professor"));
+    }
+
+    @Test
+    void registerProfessorReturns400WhenEmailIsInvalid() throws Exception {
+        ProfessorRegisterRequest request = new ProfessorRegisterRequest(
+                "Dr. Jane Doe",
+                "not-an-email",
+                "SecurePass123!",
+                "professor"
+        );
+
+        mockMvc.perform(post("/api/v1/professors/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("email must be a valid email address."));
+    }
+
+    @Test
+    void registerProfessorReturns400WhenRoleIsInvalid() throws Exception {
+        ProfessorRegisterRequest request = new ProfessorRegisterRequest(
+                "Dr. Jane Doe",
+                "jane.doe@university.edu",
+                "SecurePass123!",
+                "advisor"
+        );
+
+        mockMvc.perform(post("/api/v1/professors/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.message").value("role must be either professor or coordinator."));
+    }
+
+    @Test
+    void registerProfessorReturns409WhenEmailAlreadyExists() throws Exception {
+        ProfessorRegisterRequest firstRequest = new ProfessorRegisterRequest(
+                "Dr. Jane Doe",
+                "jane.doe@university.edu",
+                "SecurePass123!",
+                "professor"
+        );
+
+        ProfessorRegisterRequest secondRequest = new ProfessorRegisterRequest(
+                "Dr. Jane Doe",
+                "JANE.DOE@UNIVERSITY.EDU",
+                "SecurePass123!",
+                "coordinator"
+        );
+
+        mockMvc.perform(post("/api/v1/professors/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(firstRequest)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/professors/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(secondRequest)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error").value("Conflict"))
+                .andExpect(jsonPath("$.message").value("A user already exists for the given email."));
+    }
+}

--- a/backend/src/test/java/com/spms/backend/repository/SupabaseUserRepositoryTest.java
+++ b/backend/src/test/java/com/spms/backend/repository/SupabaseUserRepositoryTest.java
@@ -50,4 +50,41 @@ class SupabaseUserRepositoryTest {
         assertTrue(userRepository.findByGithubUsername("furkangncr").isEmpty());
         assertEquals("furkangncr-updated", userRepository.findByStudentId("11070001000").orElseThrow().getGithubUsername());
     }
+
+    @Test
+    void saveFindsUserByEmailCaseInsensitively() {
+        User user = new User();
+        user.setFullName("Dr. Jane Doe");
+        user.setEmail("Jane.Doe@University.edu");
+        user.setPasswordHash("hashed-password");
+        user.setRole("professor");
+        user.setCreatedAt(Instant.now());
+
+        User savedUser = userRepository.save(user);
+
+        assertNotNull(savedUser.getUserId());
+        assertTrue(userRepository.findByEmail("jane.doe@university.edu").isPresent());
+        assertTrue(userRepository.findByEmail("JANE.DOE@UNIVERSITY.EDU").isPresent());
+    }
+
+    @Test
+    void saveUpdatesEmailIndexForExistingUser() {
+        User user = new User();
+        user.setFullName("Dr. Jane Doe");
+        user.setEmail("jane.doe@university.edu");
+        user.setPasswordHash("hashed-password");
+        user.setRole("coordinator");
+        user.setCreatedAt(Instant.now());
+
+        User savedUser = userRepository.save(user);
+        savedUser.setEmail("jane.updated@university.edu");
+        userRepository.save(savedUser);
+
+        assertTrue(userRepository.findByEmail("jane.updated@university.edu").isPresent());
+        assertTrue(userRepository.findByEmail("jane.doe@university.edu").isEmpty());
+        assertEquals(
+                "jane.updated@university.edu",
+                userRepository.findByEmail("jane.updated@university.edu").orElseThrow().getEmail()
+        );
+    }
 }

--- a/backend/src/test/java/com/spms/backend/service/ProfessorRegistrationServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/ProfessorRegistrationServiceTest.java
@@ -1,0 +1,87 @@
+package com.spms.backend.service;
+
+import com.spms.backend.dto.request.ProfessorRegisterRequest;
+import com.spms.backend.dto.response.ProfessorRegisterResponse;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.exception.DuplicateUserException;
+import com.spms.backend.model.User;
+import com.spms.backend.repository.SupabaseUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProfessorRegistrationServiceTest {
+
+    private SupabaseUserRepository userRepository;
+    private ProfessorRegistrationService professorRegistrationService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = new SupabaseUserRepository();
+        professorRegistrationService = new ProfessorRegistrationService(userRepository);
+    }
+
+    @Test
+    void registerProfessorCreatesNewCoordinatorUserWithHashedPassword() {
+        ProfessorRegisterResponse response = professorRegistrationService.registerProfessor(
+                new ProfessorRegisterRequest(
+                        "Dr. Jane Doe",
+                        "jane.doe@university.edu",
+                        "SecurePass123!",
+                        "coordinator"
+                )
+        );
+
+        User savedUser = userRepository.findByEmail("JANE.DOE@UNIVERSITY.EDU").orElseThrow();
+
+        assertNotNull(response.userId());
+        assertEquals("coordinator", response.role());
+        assertNotNull(savedUser.getPasswordHash());
+        assertNotEquals("SecurePass123!", savedUser.getPasswordHash());
+        assertTrue(professorRegistrationService.matchesPassword("SecurePass123!", savedUser.getPasswordHash()));
+    }
+
+    @Test
+    void registerProfessorRejectsInvalidRole() {
+        assertThrows(
+                BadRequestException.class,
+                () -> professorRegistrationService.registerProfessor(
+                        new ProfessorRegisterRequest(
+                                "Dr. Jane Doe",
+                                "jane.doe@university.edu",
+                                "SecurePass123!",
+                                "advisor"
+                        )
+                )
+        );
+    }
+
+    @Test
+    void registerProfessorRejectsDuplicateEmailCaseInsensitively() {
+        professorRegistrationService.registerProfessor(
+                new ProfessorRegisterRequest(
+                        "Dr. Jane Doe",
+                        "jane.doe@university.edu",
+                        "SecurePass123!",
+                        "professor"
+                )
+        );
+
+        assertThrows(
+                DuplicateUserException.class,
+                () -> professorRegistrationService.registerProfessor(
+                        new ProfessorRegisterRequest(
+                                "Dr. Jane Doe",
+                                "JANE.DOE@UNIVERSITY.EDU",
+                                "AnotherSecurePass123!",
+                                "coordinator"
+                        )
+                )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the backend slice for Issue #10 in the SPMS project.

It implements the professor/coordinator registration path under Process 1 (User Registration), and is limited to the manual professor/coordinator creation flow. It does not change the student GitHub OAuth registration path.

## What Was Implemented

- Added `POST /api/v1/professors/register`
- Added request validation for `fullName`, `email`, `password`, and `role`
- Restricted `role` to `professor` or `coordinator`
- Added duplicate email detection with `409 Conflict`
- Added secure password hashing before persistence
- Added creation of the user record in D1 through the existing repository abstraction
- Reused the existing backend structure introduced in Issue #7 instead of creating parallel architecture

## Project / DFD / API Alignment

This PR is aligned with:

- Process 1 user registration flow
- the professor/coordinator manual registration path
- Level 2 Process 1 step `1.6 Register Professor`
- the OpenAPI contract for `POST /professors/register`

## Temporary Persistence Note

Real Supabase integration is still not ready.

This PR extends the current temporary `SupabaseUserRepository` stub-based persistence by adding email lookup and `passwordHash` storage in a way that can later be migrated to real Supabase.

When the real database/schema is ready, only the repository internals should need updating, while controller/service/API behavior should remain the same.

## Acceptance Criteria Coverage

This PR satisfies the Issue #10 acceptance criteria:

- endpoint accepts `fullName`, `email`, `password`, `role`
- returns `409` if email already exists
- passwords are not stored in plain text

## Testing

Tests were added/updated for:

- successful registration
- invalid role / invalid request
- duplicate email conflict
- repository email lookup behavior
- password is stored hashed, not raw

Validation command:
`mvn -Dmaven.repo.local=/tmp/spms-m2 test`

This command passed successfully.

## Notes

This PR should be reviewed as a stacked PR on top of the Issue #7 backend groundwork.
It should remain based on `feature/issue-7-github-callback` until Issue #7 is merged.