### PR TITLE
feat: implement change password endpoint (Resolves #27)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/spms/backend/controller/AuthController.java
@@ -1,21 +1,23 @@
 package com.spms.backend.controller;
 
+import com.spms.backend.dto.request.PasswordChangeRequest;
 import com.spms.backend.dto.response.GithubCallbackResponse;
 import com.spms.backend.service.GithubOAuthService;
+import com.spms.backend.service.PasswordService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
     private final GithubOAuthService githubOAuthService;
+    private final PasswordService passwordService;
 
-    public AuthController(GithubOAuthService githubOAuthService) {
+    public AuthController(GithubOAuthService githubOAuthService,
+                          PasswordService passwordService) {
         this.githubOAuthService = githubOAuthService;
+        this.passwordService = passwordService;
     }
 
     @GetMapping("/github/callback")
@@ -24,5 +26,13 @@ public class AuthController {
             @RequestParam(required = false) String state
     ) {
         return ResponseEntity.ok(githubOAuthService.handleCallback(code, state));
+    }
+
+    @PostMapping("/change-password")
+    public ResponseEntity<String> changePassword(@RequestBody PasswordChangeRequest request) {
+
+        passwordService.changePassword(request);
+
+        return ResponseEntity.ok("Password updated successfully.");
     }
 }

--- a/backend/src/main/java/com/spms/backend/dto/request/PasswordChangeRequest.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,19 @@
+package com.spms.backend.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PasswordChangeRequest(
+
+        @Email(message = "Email must be valid.")
+        @NotBlank(message = "Email is required.")
+        String email,
+
+        @NotBlank(message = "Temporary password is required.")
+        String tempPassword,
+
+        @NotBlank(message = "New password is required.")
+        String newPassword
+
+) {
+}

--- a/backend/src/main/java/com/spms/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/spms/backend/exception/GlobalExceptionHandler.java
@@ -21,6 +21,11 @@ public class GlobalExceptionHandler {
         return buildResponse(HttpStatus.UNAUTHORIZED, exception.getMessage());
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<ErrorResponse> handleUnauthorized(UnauthorizedException exception) {
+        return buildResponse(HttpStatus.UNAUTHORIZED, exception.getMessage());
+    }
+
     @ExceptionHandler(DuplicateUserException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateUser(DuplicateUserException exception) {
         return buildResponse(HttpStatus.CONFLICT, exception.getMessage());

--- a/backend/src/main/java/com/spms/backend/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/spms/backend/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.spms.backend.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/spms/backend/model/User.java
+++ b/backend/src/main/java/com/spms/backend/model/User.java
@@ -11,6 +11,8 @@ public class User {
     private String githubUsername;
     private String role;
     private Instant createdAt;
+    private String passwordHash;
+    private boolean requiresPasswordChange;
 
     public User() {
     }
@@ -23,6 +25,8 @@ public class User {
         this.githubUsername = other.githubUsername;
         this.role = other.role;
         this.createdAt = other.createdAt;
+        this.passwordHash = other.passwordHash;
+        this.requiresPasswordChange = other.requiresPasswordChange;
     }
 
     public Long getUserId() {
@@ -79,5 +83,21 @@ public class User {
 
     public void setCreatedAt(Instant createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public boolean isRequiresPasswordChange() {
+        return requiresPasswordChange;
+    }
+
+    public void setRequiresPasswordChange(boolean requiresPasswordChange) {
+        this.requiresPasswordChange = requiresPasswordChange;
     }
 }

--- a/backend/src/main/java/com/spms/backend/service/PasswordService.java
+++ b/backend/src/main/java/com/spms/backend/service/PasswordService.java
@@ -1,0 +1,57 @@
+package com.spms.backend.service;
+
+import com.spms.backend.dto.request.PasswordChangeRequest;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.model.User;
+import com.spms.backend.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import com.spms.backend.exception.UnauthorizedException;
+
+import java.util.Optional;
+
+@Service
+public class PasswordService {
+
+    private final UserRepository userRepository;
+
+    public PasswordService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public void changePassword(PasswordChangeRequest request) {
+
+        String email = requireText(request.email(), "Email is required.");
+        String tempPassword = requireText(request.tempPassword(), "Temporary password is required.");
+        String newPassword = requireText(request.newPassword(), "New password is required.");
+
+        
+        Optional<User> optionalUser = userRepository.findByStudentId(email);
+
+        if (optionalUser.isEmpty()) {
+            throw new BadRequestException("User not found.");
+        }
+
+        User user = optionalUser.get();
+
+        
+        if (!tempPassword.equals(user.getPasswordHash())) {
+            throw new UnauthorizedException("Temporary password is incorrect.");
+        }
+
+       
+        user.setPasswordHash(newPassword);
+
+     
+        user.setRequiresPasswordChange(false);
+
+        userRepository.save(user);
+    }
+
+    private String requireText(String value, String message) {
+        if (!StringUtils.hasText(value)) {
+            throw new BadRequestException(message);
+        }
+        return value.trim();
+    }
+}


### PR DESCRIPTION
Summary
This PR implements the backend logic for Issue #27 (Change Password functionality for professors).

It introduces the required API flow for:

POST /api/v1/auth/change-password

What Was Implemented
Backend (Spring Boot):

Added POST /api/v1/auth/change-password endpoint in AuthController.
Created PasswordChangeRequest DTO to handle request validation.
Implemented PasswordService to handle password update logic:
- Validates tempPassword against stored password
- Updates password (basic implementation)
- Clears requiresPasswordChange flag
Added UnauthorizedException for authentication-related failures.
Updated GlobalExceptionHandler to return 401 Unauthorized for invalid tempPassword.

Data Model:

Extended User model with:
- passwordHash field
- requiresPasswordChange flag

Scope Boundaries
This PR intentionally stays within Issue #27 scope only.

It does not implement:

Full password hashing (currently basic string assignment)
Login/authentication flow validation after password change
Database integration (repository currently uses in-memory storage)
Frontend integration

Temporary Limitations / Known Issues
UserRepository is currently an in-memory implementation, so data is lost after server restart.
Password hashing is not implemented yet (will be handled in future security tasks).
Email field is temporarily treated as studentId for lookup.

Testing
Tested using Postman:

1. Created a user via:
POST /api/v1/users/register/student

2. Tested change password endpoint:
POST /api/v1/auth/change-password

Verified:
- Returns 401 when tempPassword is incorrect
- Returns appropriate error response format