### PR TITLE
feat: add github oauth initiation endpoint (Resolves #6)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/spms/backend/controller/AuthController.java
@@ -7,6 +7,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import com.spms.backend.dto.request.GithubAuthRequest;
+import com.spms.backend.dto.response.GithubAuthResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -25,4 +29,14 @@ public class AuthController {
     ) {
         return ResponseEntity.ok(githubOAuthService.handleCallback(code, state));
     }
+
+    @PostMapping("/github")
+public ResponseEntity<GithubAuthResponse> startGithubAuth(
+        @RequestBody GithubAuthRequest request
+) {
+    String authorizationUrl = githubOAuthService.generateGithubAuthorizationUrl(request.studentId());
+
+    return ResponseEntity.ok(new GithubAuthResponse(authorizationUrl));
+}
+
 }

--- a/backend/src/main/java/com/spms/backend/dto/request/GithubAuthRequest.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/GithubAuthRequest.java
@@ -1,0 +1,5 @@
+package com.spms.backend.dto.request;
+
+public record GithubAuthRequest(
+    String studentId
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/GithubAuthResponse.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/GithubAuthResponse.java
@@ -1,0 +1,5 @@
+package com.spms.backend.dto.response;
+
+public record GithubAuthResponse(
+    String authorizationUrl
+) {}

--- a/backend/src/main/java/com/spms/backend/service/GithubOAuthService.java
+++ b/backend/src/main/java/com/spms/backend/service/GithubOAuthService.java
@@ -7,6 +7,7 @@ import com.spms.backend.exception.BadRequestException;
 import com.spms.backend.model.User;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import com.spms.backend.config.GithubProperties;
 
 @Service
 public class GithubOAuthService {
@@ -14,15 +15,18 @@ public class GithubOAuthService {
     private final GithubApiClient githubApiClient;
     private final StudentRegistrationService studentRegistrationService;
     private final TokenService tokenService;
+    private final GithubProperties githubProperties;
 
     public GithubOAuthService(
             GithubApiClient githubApiClient,
             StudentRegistrationService studentRegistrationService,
-            TokenService tokenService
+            TokenService tokenService,
+            GithubProperties githubProperties
     ) {
         this.githubApiClient = githubApiClient;
         this.studentRegistrationService = studentRegistrationService;
         this.tokenService = tokenService;
+        this.githubProperties = githubProperties;
     }
 
     public GithubCallbackResponse handleCallback(String code, String state) {
@@ -52,4 +56,27 @@ public class GithubOAuthService {
         }
         return value.trim();
     }
+
+    public String generateGithubAuthorizationUrl(String studentId) {
+    String validatedStudentId = requireText(studentId, "studentId is required.");
+
+    // student var mı kontrol
+    boolean exists = studentRegistrationService.validateStudent(validatedStudentId);
+    if (!exists) {
+        throw new BadRequestException("Student ID not found.");
+    }
+
+    String clientId = githubProperties.getClientId();
+    String redirectUri = githubProperties.getRedirectUri();
+
+    String scope = "read:user";
+    String state = validatedStudentId;
+
+    return "https://github.com/login/oauth/authorize"
+            + "?client_id=" + clientId
+            + "&redirect_uri=" + redirectUri
+            + "&scope=" + scope
+            + "&state=" + state;
+    }
+
 }


### PR DESCRIPTION
## Summary

This pull request implements the GitHub OAuth initiation flow for Issue #6. The purpose of this feature is to start the GitHub authentication process by generating an authorization URL for a validated student.

---

## Implementation Details

A new endpoint has been added to start the GitHub OAuth flow:

POST /api/v1/auth/github

The endpoint accepts a studentId in the request body. The backend validates the provided studentId, checks whether the student exists in the system, and generates a GitHub authorization URL.

The implementation includes the following components:

- A request DTO (GithubAuthRequest) to receive studentId
- A response DTO (GithubAuthResponse) to return the generated authorizationUrl
- Authorization URL generation logic added to GithubOAuthService
- Validation of studentId before starting the OAuth flow
- Use of the state parameter to carry the validated studentId through the callback process

The generated authorization URL includes:

- client_id
- redirect_uri
- scope
- state

The state parameter is used to preserve the validated studentId so that it can be recovered during the callback step.

---

## System Flow

1. A POST request is sent to /api/v1/auth/github with a studentId
2. The backend validates that the studentId is present
3. The system checks whether the student exists in the repository
4. If the student is valid, the backend generates a GitHub authorization URL
5. The response is returned with the generated authorizationUrl

---

## Scope Boundaries

This implementation is limited to the requirements of Issue #6. It only covers the initiation step of the GitHub OAuth process.

The following features are intentionally outside the scope of this pull request:

- GitHub callback handling logic changes
- Frontend redirection logic
- Persistent database integration
- Advanced OAuth security enhancements such as encoded state payloads

---

## Temporary Limitations / Known Issues

The current implementation has the following limitations:

- The student repository currently uses in-memory storage
- The state parameter directly carries the validated studentId
- URL parameters are assembled directly without additional encoding utilities
- Full production-level OAuth hardening is not included in this scope

---

## Testing

The feature has been tested using Postman with the following scenarios:

1. Valid request  
   A POST request with a valid studentId returns a generated GitHub authorization URL.

2. Missing studentId  
   The system returns a 400 Bad Request response.

3. Non-existing studentId  
   The system returns a 400 Bad Request response.

The generated authorization URL was verified to include the expected OAuth parameters.

---

## Result

The system is now able to initiate the GitHub OAuth flow for a validated student by generating an authorization URL. This establishes the first step of the GitHub authentication process required by the project.

---

Resolves #6