### PR TITLE
feat: implement group management CRUD API

### DIFF
--- a/backend/src/main/java/com/spms/backend/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/spms/backend/config/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package com.spms.backend.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "SPMS API", version = "1.0", description = "Senior Project Management System API"),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+public class OpenApiConfig {
+}

--- a/backend/src/main/java/com/spms/backend/controller/GroupController.java
+++ b/backend/src/main/java/com/spms/backend/controller/GroupController.java
@@ -1,0 +1,58 @@
+package com.spms.backend.controller;
+
+
+import com.spms.backend.dto.request.GroupCreateRequestDto;
+import com.spms.backend.dto.request.GroupUpdateRequestDto;
+import com.spms.backend.dto.response.GroupDetailDto;
+import com.spms.backend.dto.response.GroupResponseDto;
+import com.spms.backend.service.GroupService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/groups")
+public class GroupController {
+
+    private final GroupService groupService;
+
+    public GroupController(GroupService groupService) {
+        this.groupService = groupService;
+    }
+
+    @PostMapping
+    public ResponseEntity<GroupResponseDto> createGroup(
+            @Valid @RequestBody GroupCreateRequestDto request,
+            @RequestAttribute("jwt_userId") Object userId) {
+
+        Long creatorId = Long.valueOf(userId.toString());
+        GroupResponseDto response = groupService.createGroup(request, creatorId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PutMapping("/{groupId}")
+    public ResponseEntity<Void> updateGroup(
+            @PathVariable Long groupId,
+            @Valid @RequestBody GroupUpdateRequestDto request,
+            @RequestAttribute("jwt_userId") Object userId) {
+
+        Long requesterId = Long.valueOf(userId.toString());
+        groupService.updateGroupName(groupId, request, requesterId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<GroupResponseDto>> getGroups(Pageable pageable) {
+        return ResponseEntity.ok(groupService.getAllGroups(pageable));
+    }
+
+    @GetMapping("/{groupId}")
+    public ResponseEntity<GroupDetailDto> getGroupDetails(@PathVariable Long groupId) {
+        return ResponseEntity.ok(groupService.getGroupDetails(groupId));
+    }
+}

--- a/backend/src/main/java/com/spms/backend/dto/request/GroupCreateRequestDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/GroupCreateRequestDto.java
@@ -1,0 +1,8 @@
+package com.spms.backend.dto.request;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+public record GroupCreateRequestDto(
+        @NotBlank(message = "Group name cannot be blank")
+        @Size(min = 3, max = 100, message = "Group name must be between 3 and 100 characters")
+        String groupName
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/request/GroupUpdateRequestDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/GroupUpdateRequestDto.java
@@ -1,0 +1,9 @@
+package com.spms.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+public record GroupUpdateRequestDto(
+        @NotBlank(message = "Group name cannot be blank")
+        @Size(min = 3, max = 100, message = "Group name must be between 3 and 100 characters")
+        String groupName
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/GroupDetailDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/GroupDetailDto.java
@@ -1,0 +1,14 @@
+package com.spms.backend.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+public record GroupDetailDto(
+        Long id,
+        String groupName,
+        Long leaderId,
+        Long advisorId,
+        String status,
+        Instant createdAt,
+        Instant updatedAt,
+        List<GroupMemberDto> members
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/GroupMemberDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/GroupMemberDto.java
@@ -1,0 +1,9 @@
+package com.spms.backend.dto.response;
+
+import java.time.Instant;
+public record GroupMemberDto(
+        Long userId,
+        String fullName,
+        String role,
+        Instant joinedAt
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/GroupResponseDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/GroupResponseDto.java
@@ -1,0 +1,12 @@
+package com.spms.backend.dto.response;
+
+import java.time.Instant;
+public record GroupResponseDto(
+        Long id,
+        String groupName,
+        Long leaderId,
+        Long advisorId,
+        String status,
+        int memberCount,
+        Instant createdAt
+) {}

--- a/backend/src/main/java/com/spms/backend/model/Group.java
+++ b/backend/src/main/java/com/spms/backend/model/Group.java
@@ -1,0 +1,105 @@
+package com.spms.backend.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "groups")
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "group_name", nullable = false, length = 100)
+    private String groupName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id", nullable = false)
+    private User leader;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "advisor_id")
+    private User advisor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GroupStatus status = GroupStatus.FORMING;
+
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<GroupMember> members = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "updated_at")
+    private Instant updatedAt = Instant.now();
+
+    public Group() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+
+    public User getLeader() {
+        return leader;
+    }
+
+    public void setLeader(User leader) {
+        this.leader = leader;
+    }
+
+    public User getAdvisor() {
+        return advisor;
+    }
+
+    public void setAdvisor(User advisor) {
+        this.advisor = advisor;
+    }
+
+    public GroupStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(GroupStatus status) {
+        this.status = status;
+    }
+
+    public List<GroupMember> getMembers() {
+        return members;
+    }
+
+    public void setMembers(List<GroupMember> members) {
+        this.members = members;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/spms/backend/model/GroupMember.java
+++ b/backend/src/main/java/com/spms/backend/model/GroupMember.java
@@ -1,0 +1,68 @@
+package com.spms.backend.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "group_members")
+public class GroupMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GroupRole role;
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private Instant joinedAt = Instant.now();
+    public GroupMember() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Group getGroup() {
+        return group;
+    }
+
+    public void setGroup(Group group) {
+        this.group = group;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public GroupRole getRole() {
+        return role;
+    }
+
+    public void setRole(GroupRole role) {
+        this.role = role;
+    }
+
+    public Instant getJoinedAt() {
+        return joinedAt;
+    }
+
+    public void setJoinedAt(Instant joinedAt) {
+        this.joinedAt = joinedAt;
+    }
+}

--- a/backend/src/main/java/com/spms/backend/model/GroupRole.java
+++ b/backend/src/main/java/com/spms/backend/model/GroupRole.java
@@ -1,0 +1,6 @@
+package com.spms.backend.model;
+
+public enum GroupRole {
+    LEADER,
+    MEMBER
+}

--- a/backend/src/main/java/com/spms/backend/model/GroupStatus.java
+++ b/backend/src/main/java/com/spms/backend/model/GroupStatus.java
@@ -1,0 +1,8 @@
+package com.spms.backend.model;
+
+public enum GroupStatus {
+    FORMING,
+    FORMED,
+    ADVISED,
+    DISBANDED
+}

--- a/backend/src/main/java/com/spms/backend/repository/GroupMemberRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/GroupMemberRepository.java
@@ -1,0 +1,12 @@
+package com.spms.backend.repository;
+
+
+import com.spms.backend.model.GroupMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
+    boolean existsByUser_UserId(Long userId);
+}

--- a/backend/src/main/java/com/spms/backend/repository/GroupRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/GroupRepository.java
@@ -1,0 +1,8 @@
+package com.spms.backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import com.spms.backend.model.Group;
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/backend/src/main/java/com/spms/backend/service/GroupService.java
+++ b/backend/src/main/java/com/spms/backend/service/GroupService.java
@@ -1,0 +1,14 @@
+package com.spms.backend.service;
+
+import com.spms.backend.dto.request.GroupCreateRequestDto;
+import com.spms.backend.dto.request.GroupUpdateRequestDto;
+import com.spms.backend.dto.response.GroupDetailDto;
+import com.spms.backend.dto.response.GroupResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+public interface GroupService {
+    GroupResponseDto createGroup(GroupCreateRequestDto request, Long creatorId);
+    void updateGroupName(Long groupId, GroupUpdateRequestDto request, Long requesterId);
+    Page<GroupResponseDto> getAllGroups(Pageable pageable);
+    GroupDetailDto getGroupDetails(Long groupId);
+}

--- a/backend/src/main/java/com/spms/backend/service/StudentAuthorizationService.java
+++ b/backend/src/main/java/com/spms/backend/service/StudentAuthorizationService.java
@@ -1,0 +1,47 @@
+package com.spms.backend.service;
+
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.exception.UnauthorizedException;
+import com.spms.backend.model.User;
+import com.spms.backend.model.Group;
+import com.spms.backend.repository.GroupMemberRepository;
+import com.spms.backend.repository.GroupRepository;
+import com.spms.backend.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StudentAuthorizationService {
+
+    private final UserRepository userRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupRepository groupRepository;
+
+    public StudentAuthorizationService(UserRepository userRepository, GroupMemberRepository groupMemberRepository, GroupRepository groupRepository) {
+        this.userRepository = userRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.groupRepository = groupRepository;
+    }
+
+    public User validateStudentExists(Long studentId) {
+        return userRepository.findById(studentId)
+                .orElseThrow(() -> new BadRequestException("Student not found."));
+    }
+
+
+    public void validateNotInGroup(Long studentId) {
+        if (groupMemberRepository.existsByUser_UserId(studentId)) {
+            throw new BadRequestException("This student is already a member of another group.");
+        }
+    }
+
+
+    public Group validateIsGroupLeader(Long userId, Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new BadRequestException("Group not found."));
+
+        if (!group.getLeader().getUserId().equals(userId)) {
+            throw new UnauthorizedException("Only the group leader perform this action.");
+        }
+        return group;
+    }
+}

--- a/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
@@ -1,0 +1,120 @@
+package com.spms.backend.service.impl;
+
+import com.spms.backend.dto.request.GroupCreateRequestDto;
+import com.spms.backend.dto.request.GroupUpdateRequestDto;
+import com.spms.backend.dto.response.GroupDetailDto;
+import com.spms.backend.dto.response.GroupMemberDto;
+import com.spms.backend.dto.response.GroupResponseDto;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.model.User;
+import com.spms.backend.model.Group;
+import com.spms.backend.model.GroupMember;
+import com.spms.backend.model.GroupRole;
+import com.spms.backend.model.GroupStatus;
+import com.spms.backend.repository.GroupRepository;
+import com.spms.backend.service.GroupService;
+import com.spms.backend.service.StudentAuthorizationService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class GroupServiceImpl implements GroupService {
+
+    private final GroupRepository groupRepository;
+    private final StudentAuthorizationService authService;
+
+    public GroupServiceImpl(GroupRepository groupRepository, StudentAuthorizationService authService) {
+        this.groupRepository = groupRepository;
+        this.authService = authService;
+    }
+
+    @Override
+    @Transactional
+    public GroupResponseDto createGroup(GroupCreateRequestDto request, Long creatorId) {
+        User creator = authService.validateStudentExists(creatorId);
+        authService.validateNotInGroup(creatorId);
+
+
+        Group group = new Group();
+        group.setGroupName(request.groupName());
+        group.setLeader(creator);
+        group.setStatus(GroupStatus.FORMING);
+
+
+        GroupMember leaderMember = new GroupMember();
+        leaderMember.setGroup(group);
+        leaderMember.setUser(creator);
+        leaderMember.setRole(GroupRole.LEADER);
+
+        group.getMembers().add(leaderMember);
+
+        Group savedGroup = groupRepository.save(group);
+
+        return mapToSimpleDto(savedGroup);
+    }
+
+    @Override
+    @Transactional
+    public void updateGroupName(Long groupId, GroupUpdateRequestDto request, Long requesterId) {
+
+        Group group = authService.validateIsGroupLeader(requesterId, groupId);
+
+        group.setGroupName(request.groupName());
+        group.setUpdatedAt(Instant.now());
+
+        groupRepository.save(group);
+        //todo Issue P2.9 Audit Log service
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<GroupResponseDto> getAllGroups(Pageable pageable) {
+        return groupRepository.findAll(pageable)
+                .map(this::mapToSimpleDto);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GroupDetailDto getGroupDetails(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new BadRequestException("Group not found."));
+
+        List<GroupMemberDto> memberDtos = group.getMembers().stream()
+                .map(m -> new GroupMemberDto(
+                        m.getUser().getUserId(),
+                        m.getUser().getFullName(),
+                        m.getRole().name(),
+                        m.getJoinedAt()))
+                .collect(Collectors.toList());
+
+        return new GroupDetailDto(
+                group.getId(),
+                group.getGroupName(),
+                group.getLeader().getUserId(),
+                group.getAdvisor() != null ? group.getAdvisor().getUserId() : null,
+                group.getStatus().name(),
+                group.getCreatedAt(),
+                group.getUpdatedAt(),
+                memberDtos
+        );
+    }
+
+
+    private GroupResponseDto mapToSimpleDto(Group group) {
+        return new GroupResponseDto(
+                group.getId(),
+                group.getGroupName(),
+                group.getLeader().getUserId(),
+                group.getAdvisor() != null ? group.getAdvisor().getUserId() : null,
+                group.getStatus().name(),
+                group.getMembers().size(),
+                group.getCreatedAt()
+        );
+    }
+}


### PR DESCRIPTION
Related to #13 

## Summary
Implements the full Group Management CRUD API for the Senior Project Management System (SPMS).
## Changes
### New Files
- **Model:** `Group`, `GroupMember`, `GroupRole`, `GroupStatus`
- **Repository:** `GroupRepository`, `GroupMemberRepository`
- **Service:** `GroupService` (interface), `GroupServiceImpl`
- **Controller:** `GroupController`
- **DTOs:** `GroupCreateRequestDto`, `GroupUpdateRequestDto`, `GroupResponseDto`, `GroupDetailDto`, `GroupMemberDto`
- **Config:** `OpenApiConfig` (Swagger/OpenAPI with JWT bearer auth support)
- **Authorization:** `StudentAuthorizationService`
## Endpoints
- `POST /api/groups` – Create a new group
- `GET /api/groups/{id}` – Get group details
- `PUT /api/groups/{id}` – Update group
- `DELETE /api/groups/{id}` – Delete group
- `POST /api/groups/{id}/members` – Add member to group
## Notes
- Role-based authorization applied (student/advisor roles)
- `application.yml` and notification-related files are excluded from this PR