### PR TITLE
Feature/advisor request approval system #31

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/CoordinatorController.java
+++ b/backend/src/main/java/com/spms/backend/controller/CoordinatorController.java
@@ -21,9 +21,11 @@ import java.util.List;
 public class CoordinatorController {
 
     private final ScheduleService scheduleService;
+    private final com.spms.backend.service.GroupService groupService;
 
-    public CoordinatorController(ScheduleService scheduleService) {
+    public CoordinatorController(ScheduleService scheduleService, com.spms.backend.service.GroupService groupService) {
         this.scheduleService = scheduleService;
+        this.groupService = groupService;
     }
 
     // ── GET /api/v1/coordinator/schedule ────────────────────────────────
@@ -73,5 +75,12 @@ public class CoordinatorController {
                 alerts.size(),
                 alerts
         ));
+    }
+
+    @Operation(summary = "Get detailed group formation report")
+    @GetMapping("/reports/group-formation")
+    public ResponseEntity<com.spms.backend.dto.response.GroupFormationReportDto> getGroupFormationReport(HttpServletRequest httpReq) {
+        String role = (String) httpReq.getAttribute("jwt_role");
+        return ResponseEntity.ok(groupService.getGroupFormationReport(role));
     }
 }

--- a/backend/src/main/java/com/spms/backend/controller/GroupController.java
+++ b/backend/src/main/java/com/spms/backend/controller/GroupController.java
@@ -180,4 +180,19 @@ public class GroupController {
                 "message", "Membership invitation sent successfully"
         ));
     }
+
+    @PostMapping("/{groupId}/advisor/transfer")
+    public ResponseEntity<?> transferAdvisor(
+            @PathVariable Long groupId,
+            @Valid @RequestBody com.spms.backend.dto.request.AdvisorTransferRequestDto request,
+            @RequestAttribute("jwt_role") Object role) {
+        
+        String requesterRole = role.toString();
+        groupService.transferAdvisor(groupId, request.professorId(), requesterRole);
+
+        return ResponseEntity.ok().body(java.util.Map.of(
+                "success", true,
+                "message", "Advisor assigned successfully"
+        ));
+    }
 }

--- a/backend/src/main/java/com/spms/backend/controller/ProfessorController.java
+++ b/backend/src/main/java/com/spms/backend/controller/ProfessorController.java
@@ -13,15 +13,25 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.spms.backend.service.GroupService;
+import com.spms.backend.dto.response.AdvisorRequestResponseDto;
+import com.spms.backend.dto.request.AdvisorRequestDecisionDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import java.util.List;
+
 @Tag(name = "Professor Management")
 @RestController
 @RequestMapping("/api/v1/professors")
 public class ProfessorController {
 
     private final ProfessorRegistrationService professorRegistrationService;
+    private final GroupService groupService;
 
-    public ProfessorController(ProfessorRegistrationService professorRegistrationService) {
+    public ProfessorController(ProfessorRegistrationService professorRegistrationService, GroupService groupService) {
         this.professorRegistrationService = professorRegistrationService;
+        this.groupService = groupService;
     }
 
     @Operation(summary = "Register a new professor or coordinator")
@@ -31,5 +41,23 @@ public class ProfessorController {
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(professorRegistrationService.registerProfessor(request));
+    }
+
+    @Operation(summary = "Get pending advisor requests for the authenticated professor")
+    @GetMapping("/advisor-requests")
+    public ResponseEntity<List<AdvisorRequestResponseDto>> getAdvisorRequests(
+            @RequestAttribute("jwt_userId") Object userId) {
+        Long professorId = Long.valueOf(userId.toString());
+        return ResponseEntity.ok(groupService.getPendingAdvisorRequests(professorId));
+    }
+
+    @Operation(summary = "Approve or reject an advisor request")
+    @PatchMapping("/advisor-requests")
+    public ResponseEntity<Void> handleAdvisorRequestDecision(
+            @Valid @RequestBody AdvisorRequestDecisionDto request,
+            @RequestAttribute("jwt_userId") Object userId) {
+        Long professorId = Long.valueOf(userId.toString());
+        groupService.handleAdvisorRequestDecision(professorId, request.groupId(), request.status());
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/spms/backend/dto/request/AdvisorRequestDecisionDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/AdvisorRequestDecisionDto.java
@@ -1,0 +1,13 @@
+package com.spms.backend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record AdvisorRequestDecisionDto(
+        @NotNull(message = "Group ID is required")
+        Long groupId,
+        
+        @NotNull(message = "Status is required")
+        @Pattern(regexp = "^(?i)(approved|rejected)$", message = "Status must be 'approved' or 'rejected'")
+        String status
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/request/AdvisorTransferRequestDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/AdvisorTransferRequestDto.java
@@ -1,0 +1,8 @@
+package com.spms.backend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AdvisorTransferRequestDto(
+        @NotNull(message = "Professor ID is required")
+        Long professorId
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/request/MemberAddRequestDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/MemberAddRequestDto.java
@@ -1,8 +1,5 @@
 package com.spms.backend.dto.request;
 
-import lombok.Data;
-
-@Data
-public class MemberAddRequestDto {
-    private String studentId;
-}
+public record MemberAddRequestDto(
+    String studentId
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/AdvisorRequestResponseDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/AdvisorRequestResponseDto.java
@@ -1,0 +1,10 @@
+package com.spms.backend.dto.response;
+
+import java.time.Instant;
+
+public record AdvisorRequestResponseDto(
+        Long notificationId,
+        Long groupId,
+        String groupName,
+        Instant requestedAt
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/GroupFormationReportDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/GroupFormationReportDto.java
@@ -1,0 +1,18 @@
+package com.spms.backend.dto.response;
+
+import java.util.List;
+
+public record GroupFormationReportDto(
+        long totalGroups,
+        long formedGroups,
+        long unadvisedGroups,
+        List<GroupStatusDetail> details
+) {
+    public record GroupStatusDetail(
+            Long groupId,
+            String groupName,
+            String status,
+            Long advisorId,
+            String advisorName
+    ) {}
+}

--- a/backend/src/main/java/com/spms/backend/dto/response/MemberResponseDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/MemberResponseDto.java
@@ -1,19 +1,8 @@
 package com.spms.backend.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class MemberResponseDto {
-    
-    private Long userId;
-    private String studentId;
-    private String fullName;
-    private String role; // "LEADER" veya "MEMBER" dönecek
-    
-}
+public record MemberResponseDto(
+    Long userId,
+    String studentId,
+    String fullName,
+    String role
+) {}

--- a/backend/src/main/java/com/spms/backend/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/NotificationRepository.java
@@ -20,4 +20,8 @@ public interface NotificationRepository extends JpaRepository<Notification,Long>
     void deleteByToUser_UserId(Long userId);
     java.util.List<Notification> findByToUser_UserIdAndTypeOrderByCreatedAtDesc(Long toUserId, NotificationType type);
     boolean existsByToUser_UserIdAndTypeAndStatusAndMessageContaining(Long toUserId, NotificationType type, NotificationStatus status, String messageSnippet);
+
+    java.util.List<Notification> findByToUser_UserIdAndTypeAndStatus(Long toUserId, NotificationType type, NotificationStatus status);
+    
+    java.util.List<Notification> findByGroupIdAndTypeAndStatusAndToUser_UserIdNot(Long groupId, NotificationType type, NotificationStatus status, Long excludedUserId);
 }

--- a/backend/src/main/java/com/spms/backend/service/GroupService.java
+++ b/backend/src/main/java/com/spms/backend/service/GroupService.java
@@ -39,4 +39,10 @@ public interface GroupService {
     void addMember(Long groupId, String studentId);
     void removeMember(Long groupId, String studentId);
     void leaveGroup(Long groupId, Long studentUserId);
+
+    // Advisor Requests & Group Formation
+    List<com.spms.backend.dto.response.AdvisorRequestResponseDto> getPendingAdvisorRequests(Long professorId);
+    void handleAdvisorRequestDecision(Long professorId, Long groupId, String status);
+    void transferAdvisor(Long groupId, Long professorId, String requesterRole);
+    com.spms.backend.dto.response.GroupFormationReportDto getGroupFormationReport(String role);
 }

--- a/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
@@ -388,12 +388,12 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
             // Lider mi üye mi kontrolü
             String role = group.getLeader().getUserId().equals(member.getUser().getUserId()) ? "LEADER" : "MEMBER";
 
-            return MemberResponseDto.builder()
-                    .userId(member.getUser().getUserId())
-                    .studentId(member.getUser().getStudentId())
-                    .fullName(member.getUser().getFullName())
-                    .role(role)
-                    .build();
+            return new MemberResponseDto(
+                    member.getUser().getUserId(),
+                    member.getUser().getStudentId(),
+                    member.getUser().getFullName(),
+                    role
+            );
         }).collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
@@ -39,6 +39,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.spms.backend.dto.response.MemberResponseDto;
+import com.spms.backend.model.notification.Notification;
+import com.spms.backend.model.notification.NotificationStatus;
+import com.spms.backend.model.notification.NotificationType;
+import com.spms.backend.repository.NotificationRepository;
+import com.spms.backend.dto.response.GroupFormationReportDto;
+import com.spms.backend.dto.response.AdvisorRequestResponseDto;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -60,6 +66,8 @@ public class GroupServiceImpl implements GroupService {
     private final GithubIntegrationRepository githubIntegrationRepository;
     private final JiraApiClient jiraApiClient;
 
+    private final NotificationRepository notificationRepository;
+
     public GroupServiceImpl(GroupRepository groupRepository,
                             GroupMemberRepository groupMemberRepository,
                             UserRepository userRepository,
@@ -68,7 +76,8 @@ public class GroupServiceImpl implements GroupService {
                             StudentAuthorizationService authService,
                             JiraIntegrationRepository jiraIntegrationRepository,
                             GithubIntegrationRepository githubIntegrationRepository,
-                            JiraApiClient jiraApiClient) {
+                            JiraApiClient jiraApiClient,
+                            NotificationRepository notificationRepository) {
         this.groupRepository = groupRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.userRepository = userRepository;
@@ -78,6 +87,7 @@ public class GroupServiceImpl implements GroupService {
         this.jiraIntegrationRepository = jiraIntegrationRepository;
         this.githubIntegrationRepository = githubIntegrationRepository;
         this.jiraApiClient = jiraApiClient;
+        this.notificationRepository = notificationRepository;
     }
 
     @Override
@@ -474,5 +484,140 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
         } catch (Exception e) {
             log.warn("Notification failed: {}", e.getMessage());
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AdvisorRequestResponseDto> getPendingAdvisorRequests(Long professorId) {
+        List<Notification> requests = notificationRepository.findByToUser_UserIdAndTypeAndStatus(
+                professorId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING);
+                
+        return requests.stream()
+                .filter(req -> req.getGroupId() != null)
+                .map(req -> {
+                    Group group = groupRepository.findById(req.getGroupId()).orElse(null);
+                    String groupName = group != null ? group.getGroupName() : "Unknown Group";
+                    return new AdvisorRequestResponseDto(req.getId(), req.getGroupId(), groupName, req.getCreatedAt());
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void handleAdvisorRequestDecision(Long professorId, Long groupId, String status) {
+        Notification request = notificationRepository.findByGroupIdAndToUser_UserIdAndTypeAndStatus(
+                groupId, professorId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING)
+                .orElseThrow(() -> new BadRequestException("Pending advisor request not found for this group."));
+                
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new NotFoundException("Group not found."));
+                
+        User professor = userRepository.findById(professorId)
+                .orElseThrow(() -> new NotFoundException("Professor not found."));
+
+        if ("approved".equalsIgnoreCase(status)) {
+            group.setAdvisor(professor);
+            group.setStatus(GroupStatus.ADVISED);
+            group.setUpdatedAt(Instant.now());
+            groupRepository.save(group);
+            
+            request.setStatus(NotificationStatus.ACCEPTED);
+            notificationRepository.save(request);
+            
+            List<Notification> otherRequests = notificationRepository.findByGroupIdAndTypeAndStatusAndToUser_UserIdNot(
+                    groupId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING, professorId);
+            for (Notification otherReq : otherRequests) {
+                otherReq.setStatus(NotificationStatus.REJECTED);
+                notificationRepository.save(otherReq);
+            }
+            
+            Notification notif = new Notification();
+            notif.setType(NotificationType.ADVISOR_DECISION);
+            notif.setStatus(NotificationStatus.PENDING);
+            notif.setMessage("Professor " + professor.getFullName() + " has approved your advisor request.");
+            notif.setGroupId(groupId);
+            notif.setFromUser(professor);
+            notif.setToUser(group.getLeader());
+            notificationRepository.save(notif);
+
+        } else if ("rejected".equalsIgnoreCase(status)) {
+            request.setStatus(NotificationStatus.REJECTED);
+            notificationRepository.save(request);
+            
+            Notification notif = new Notification();
+            notif.setType(NotificationType.ADVISOR_DECISION);
+            notif.setStatus(NotificationStatus.PENDING);
+            notif.setMessage("Professor " + professor.getFullName() + " has rejected your advisor request.");
+            notif.setGroupId(groupId);
+            notif.setFromUser(professor);
+            notif.setToUser(group.getLeader());
+            notificationRepository.save(notif);
+        } else {
+            throw new BadRequestException("Status must be 'approved' or 'rejected'.");
+        }
+    }
+
+    @Override
+    @Transactional
+    public void transferAdvisor(Long groupId, Long professorId, String requesterRole) {
+        if (!"coordinator".equalsIgnoreCase(requesterRole)) {
+            throw new ForbiddenException("Only coordinators can transfer advisors.");
+        }
+        
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new NotFoundException("Group not found."));
+                
+        User professor = userRepository.findById(professorId)
+                .orElseThrow(() -> new NotFoundException("Professor not found."));
+                
+        group.setAdvisor(professor);
+        group.setStatus(GroupStatus.ADVISED);
+        group.setUpdatedAt(Instant.now());
+        groupRepository.save(group);
+
+        Notification notif = new Notification();
+        notif.setType(NotificationType.SYSTEM_ALERT);
+        notif.setStatus(NotificationStatus.PENDING);
+        notif.setMessage("You have been directly assigned as advisor to group: " + group.getGroupName() + " by the coordinator.");
+        notif.setGroupId(groupId);
+        notif.setToUser(professor);
+        notificationRepository.save(notif);
+        
+        List<Notification> pendingRequests = notificationRepository.findByGroupIdAndTypeAndStatusAndToUser_UserIdNot(
+                groupId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING, -1L);
+        for (Notification req : pendingRequests) {
+            req.setStatus(NotificationStatus.REJECTED);
+            notificationRepository.save(req);
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public GroupFormationReportDto getGroupFormationReport(String role) {
+        if (!"coordinator".equalsIgnoreCase(role)) {
+            throw new ForbiddenException("Only coordinators can view group formation reports.");
+        }
+        
+        List<Group> allGroups = groupRepository.findAll();
+        long totalGroups = allGroups.size();
+        
+        long formedGroupsCnt = allGroups.stream()
+                .filter(g -> g.getStatus() == GroupStatus.FORMED || g.getStatus() == GroupStatus.ADVISED)
+                .count();
+                
+        long unadvisedGroupsCnt = allGroups.stream()
+                .filter(g -> g.getAdvisor() == null && g.getStatus() != GroupStatus.DISBANDED)
+                .count();
+                
+        List<GroupFormationReportDto.GroupStatusDetail> details = allGroups.stream()
+                .map(g -> new GroupFormationReportDto.GroupStatusDetail(
+                        g.getId(),
+                        g.getGroupName(),
+                        g.getStatus().name(),
+                        g.getAdvisor() != null ? g.getAdvisor().getUserId() : null,
+                        g.getAdvisor() != null ? g.getAdvisor().getFullName() : null
+                )).collect(Collectors.toList());
+                
+        return new GroupFormationReportDto(totalGroups, formedGroupsCnt, unadvisedGroupsCnt, details);
     }
 }

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -4,9 +4,11 @@ import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { setAuth, decodeToken } from "@/lib/auth";
 
+import { Suspense } from "react";
+
 type Status = "loading" | "error";
 
-export default function CallbackPage() {
+function CallbackContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [status, setStatus] = useState<Status>("loading");
@@ -90,5 +92,20 @@ export default function CallbackPage() {
         <p className="text-sm text-gray-500">Completing sign in...</p>
       </div>
     </div>
+  );
+}
+
+export default function CallbackPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen bg-gray-950 flex items-center justify-center text-white">
+        <svg className="w-6 h-6 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+        </svg>
+      </div>
+    }>
+      <CallbackContent />
+    </Suspense>
   );
 }

--- a/frontend/app/professor/advisor-requests/page.tsx
+++ b/frontend/app/professor/advisor-requests/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getUser, getToken } from "@/lib/auth";
+import Sidebar from "@/components/Sidebar";
+
+interface AdvisorRequest {
+  notificationId: number;
+  groupId: number;
+  groupName: string;
+  requestedAt: string;
+}
+
+export default function AdvisorRequestsPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<ReturnType<typeof getUser>>(null);
+  const [requests, setRequests] = useState<AdvisorRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = getToken();
+    const u = getUser();
+
+    if (!token || !u || u.role !== "professor") {
+      router.replace("/auth/login");
+      return;
+    }
+
+    setUser(u);
+    fetchRequests(token);
+  }, [router]);
+
+  const fetchRequests = async (token: string) => {
+    setLoading(true);
+    try {
+      const res = await fetch("http://localhost:8080/api/v1/professors/advisor-requests", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to fetch requests");
+      }
+      
+      const data = await res.json();
+      setRequests(data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDecision = async (groupId: number, status: "approved" | "rejected") => {
+    const token = getToken();
+    try {
+      const res = await fetch("http://localhost:8080/api/v1/professors/advisor-requests", {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ groupId, status }),
+      });
+
+      if (!res.ok) {
+        throw new Error("Failed to process decision");
+      }
+
+      // Automatically remove from the local list
+      setRequests((prev) => prev.filter((r) => r.groupId !== groupId));
+      alert(`Request has been ${status}.`);
+    } catch (err: any) {
+      alert("Error: " + err.message);
+    }
+  };
+
+  if (!user) return (
+    <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+      <svg className="w-6 h-6 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-950 flex">
+      <Sidebar activePage="advisor-requests" />
+
+      <main className="flex-1 flex flex-col min-w-0">
+        <div className="border-b border-white/5 px-8 py-4">
+          <h1 className="text-base font-semibold text-white">Advisor Requests</h1>
+          <p className="text-xs text-gray-500 mt-0.5">Manage group requests for advisorship</p>
+        </div>
+
+        <div className="flex-1 p-8 overflow-auto">
+          {loading ? (
+            <div className="flex justify-center mt-10">
+              <svg className="w-6 h-6 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            </div>
+          ) : error ? (
+            <div className="text-red-500 text-sm">{error}</div>
+          ) : requests.length === 0 ? (
+            <div className="text-center space-y-3 mt-10">
+              <p className="text-sm text-gray-500">No pending advisor requests.</p>
+            </div>
+          ) : (
+            <div className="grid gap-4 max-w-3xl">
+              {requests.map((req) => (
+                <div key={req.notificationId} className="bg-white/5 border border-white/10 rounded-xl p-5 flex items-center justify-between">
+                  <div>
+                    <h3 className="text-sm font-medium text-white">{req.groupName}</h3>
+                    <p className="text-xs text-gray-400 mt-1">Requested on: {new Date(req.requestedAt).toLocaleDateString()}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleDecision(req.groupId, "approved")}
+                      className="px-3 py-1.5 text-xs font-medium bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      onClick={() => handleDecision(req.groupId, "rejected")}
+                      className="px-3 py-1.5 text-xs font-medium bg-red-600/20 hover:bg-red-600/30 text-red-400 rounded-lg transition-colors border border-red-500/20"
+                    >
+                      Reject
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/GithubStatusCard.tsx
+++ b/frontend/components/GithubStatusCard.tsx
@@ -3,7 +3,11 @@
 import { GithubIntegration } from "@/lib/github-types";
 
 type Props = {
-    integration?: GithubIntegration;
+    integration?: {
+        status: string;
+        organizationName?: string | null;
+        connectedAt?: string | null;
+    } | null;
 };
 
 export default function GithubStatusCard({ integration }: Props) {

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -91,6 +91,18 @@ export default function Sidebar({ activePage }: { activePage: string }) {
           </>
         )}
 
+        {user.role === "professor" && (
+          <>
+            <p className="text-xs font-medium text-gray-600 px-3 mt-4 mb-2 uppercase tracking-widest">Advising</p>
+            <NavItem 
+              label="Advisor Requests" 
+              active={activePage === "advisor-requests"} 
+              href="/professor/advisor-requests" 
+              icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 011.04 0l2.125 5.111a.563.563 0 00.475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 00-.182.557l1.285 5.385a.562.562 0 01-.84.61l-4.725-2.885a.563.563 0 00-.586 0L6.982 20.54a.562.562 0 01-.84-.61l1.285-5.386a.562.562 0 00-.182-.557l-4.204-3.602a.563.563 0 01.321-.988l5.518-.442a.563.563 0 00.475-.345L11.48 3.5z" /></svg>} 
+            />
+          </>
+        )}
+
         {(user.role === "coordinator" || user.role === "professor") && (
           <>
              <p className="text-xs font-medium text-gray-600 px-3 mt-4 mb-2 uppercase tracking-widest">Personnel</p>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -27,7 +33,10 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
# Pull Request: Advisor Request Approval System (#31)

## Problem Summary
This pull request introduces the full-stack implementation of the Advisor Request Approval system. Previously, there was no centralized system for professors to review or decide upon advisor requests globally, nor was there a mechanism to prevent groups from simultaneously receiving multiple advisors or having conflicting advisor assignments. Additionally, coordinators needed a clear way to directly assign advisors to groups and generate high-level formation reports indicating exactly which groups are unadvised.

## Solution

The implementation is broken down into three core components affecting both the backend infrastructure and frontend UI:

### 1. Professor Advisor Requests Portal
- **Added comprehensive backend APIs (`/api/v1/professors/advisor-requests`):** 
  - Exposes pending requests meant directly for the authenticated professor.
  - Allows professors to seamlessly "Approve" or "Reject" requests via `PATCH`. 
- **Automated Conflict Resolution (`ns_f10` criteria):** When a professor approves a group's request, the group's status transitions to `ADVISED` and the system automatically rejects all other pending requests issued by that group to ensure a group can't possess multiple advisors simultaneously. A formal notification (`ADVISOR_DECISION`) is then dispatched to the relevant group leader.
- **Dedicated Frontend Dashboard (`/professor/advisor-requests`):** Professor accounts now have a robust UI component mapping out pending groupings allowing for straightforward one-click approval workflows. The professor routing configuration and sidebars have been expanded.

### 2. Coordinator Direct Assignment Access
- **Bypass Workflow API (`POST /api/v1/groups/{groupId}/advisor/transfer`):** Authorizes system coordinators to unconditionally override waitlists and directly assign any group to a specific professor.
- When an advisor is manually attached, a `SYSTEM_ALERT` serves to forcefully notify the receiving professor of their newly minted obligations, while any of that group's active requests are subsequently canceled implicitly.

### 3. Reporting Infrastructure 
- **Systematic Audit API (`GET /api/v1/coordinator/reports/group-formation`):** Provides a snapshot report highlighting crucial assignment metrics: `totalGroups`, `formedGroups`, and `unadvisedGroups`. Outlines a detailed collection detailing precisely where each group stands in the advising cycle.

### Additional Quality Fixes
- **Build Stabilization & Compilation Restorations:** Resolved legacy build failures triggered by missing Lombok processes. The `MemberResponseDto` and companion models natively moved to Java Records implementation removing the builder configuration debt permanently.
- **Frontend App Directory Types Restored:** Enforced Suspense boundaries over `useSearchParams` within Next.js `Callback` routines, and successfully patched type mismatches causing `GithubStatusCard` UI blockages during builds.

## How to Test
1. **Approval Process:** Log in as a Professor. Navigate to the newly assigned sidebar entry "Advisor Requests". Ensure any pending requests show appropriately. Wait, accept a request, verify you are successfully assigned as the group's advisor, and ensure other potential requests generated by that group are flushed from system.
2. **Coordinator Bypassing:** Log in as a Coordinator and make an assignment via `/api/v1/groups/{groupId}/advisor/transfer`. Expect the chosen professor to intercept a localized System Alert advising them of the change.
3. **Reports Checking:** Have the coordinator visit the group formation reports endpoint to witness accurate live formations counting the unadvised groups distinctively.
