### PR TITLE
Ready for PR: feature/Auto-Reject-Pending-Advisor-Requests-#33

### DIFF
--- a/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
@@ -43,6 +43,8 @@ import com.spms.backend.model.notification.Notification;
 import com.spms.backend.model.notification.NotificationStatus;
 import com.spms.backend.model.notification.NotificationType;
 import com.spms.backend.repository.NotificationRepository;
+import com.spms.backend.repository.AuditLogRepository;
+import com.spms.backend.model.AuditLog;
 import com.spms.backend.dto.response.GroupFormationReportDto;
 import com.spms.backend.dto.response.AdvisorRequestResponseDto;
 
@@ -66,16 +68,18 @@ public class GroupServiceImpl implements GroupService {
     private final JiraApiClient jiraApiClient;
 
     private final NotificationRepository notificationRepository;
+    private final AuditLogRepository auditLogRepository;
 
     public GroupServiceImpl(GroupRepository groupRepository,
-                            GroupMemberRepository groupMemberRepository,
-                            UserRepository userRepository,
-                            NotificationService notificationService,
-                            StudentAuthorizationService authService,
-                            JiraIntegrationRepository jiraIntegrationRepository,
-                            GithubIntegrationRepository githubIntegrationRepository,
-                            JiraApiClient jiraApiClient,
-                            NotificationRepository notificationRepository) {
+            GroupMemberRepository groupMemberRepository,
+            UserRepository userRepository,
+            NotificationService notificationService,
+            StudentAuthorizationService authService,
+            JiraIntegrationRepository jiraIntegrationRepository,
+            GithubIntegrationRepository githubIntegrationRepository,
+            JiraApiClient jiraApiClient,
+            NotificationRepository notificationRepository,
+            AuditLogRepository auditLogRepository) {
         this.groupRepository = groupRepository;
         this.groupMemberRepository = groupMemberRepository;
         this.userRepository = userRepository;
@@ -85,6 +89,7 @@ public class GroupServiceImpl implements GroupService {
         this.githubIntegrationRepository = githubIntegrationRepository;
         this.jiraApiClient = jiraApiClient;
         this.notificationRepository = notificationRepository;
+        this.auditLogRepository = auditLogRepository;
     }
 
     @Override
@@ -140,50 +145,49 @@ public class GroupServiceImpl implements GroupService {
         group.setUpdatedAt(Instant.now());
 
         groupRepository.save(group);
-        
+
     }
 
     // rol bazlı grup getirmek için
     @Override
     @Transactional(readOnly = true)
-public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, String requesterRole) {
+    public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, String requesterRole) {
 
-    Page<Group> groupsPage = null;
+        Page<Group> groupsPage = null;
 
-    String role = (requesterRole != null) ? requesterRole.toLowerCase() : "guest";
+        String role = (requesterRole != null) ? requesterRole.toLowerCase() : "guest";
 
-    switch (role) {
-        case "student":
-            groupsPage = groupRepository.findAllWithStudentGroupFirst(requesterId, pageable);
-            break;
+        switch (role) {
+            case "student":
+                groupsPage = groupRepository.findAllWithStudentGroupFirst(requesterId, pageable);
+                break;
 
-        case "professor":
-            groupsPage = groupRepository.findByAdvisorId(requesterId, pageable);
-            break;
+            case "professor":
+                groupsPage = groupRepository.findByAdvisorId(requesterId, pageable);
+                break;
 
-        case "coordinator":
-            groupsPage = groupRepository.findAll(pageable);
-            try {
-                List<Object[]> counts = groupRepository.countGroupsByStatus();
-                counts.forEach(result -> 
-                    log.info("Coordinator Summary - Status: {} Count: {}", result[0], result[1])
-                );
-            } catch (Exception e) {
-                log.error("Status summary count failed", e);
-            }
-            break;
+            case "coordinator":
+                groupsPage = groupRepository.findAll(pageable);
+                try {
+                    List<Object[]> counts = groupRepository.countGroupsByStatus();
+                    counts.forEach(
+                            result -> log.info("Coordinator Summary - Status: {} Count: {}", result[0], result[1]));
+                } catch (Exception e) {
+                    log.error("Status summary count failed", e);
+                }
+                break;
 
-        default:
+            default:
 
-            groupsPage = groupRepository.findAll(pageable);
-            break;
+                groupsPage = groupRepository.findAll(pageable);
+                break;
+        }
+        if (groupsPage == null) {
+            return Page.empty(pageable);
+        }
+
+        return groupsPage.map(this::mapToSimpleDto);
     }
-    if (groupsPage == null) {
-        return Page.empty(pageable);
-    }
-
-    return groupsPage.map(this::mapToSimpleDto);
-}
 
     // rol abzlı detayları getirir
     @Override
@@ -208,8 +212,7 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
                 group.getStatus().name(),
                 group.getCreatedAt(),
                 group.getUpdatedAt(),
-                memberDtos
-        );
+                memberDtos);
     }
 
     @Override
@@ -250,9 +253,6 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
         }
     }
 
-
-
-
     @Override
     @Transactional
     @AuditableOperation(actionType = ActionType.INTEGRATION_BOUND)
@@ -262,7 +262,8 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
 
         ensureRequesterIsGroupLeader(group, requesterId);
 
-        boolean valid = jiraApiClient.validateSpaceConnection(request.jiraSpaceUrl(), request.projectKey(), request.apiKey());
+        boolean valid = jiraApiClient.validateSpaceConnection(request.jiraSpaceUrl(), request.projectKey(),
+                request.apiKey());
         if (!valid) {
             throw new BadRequestException("JIRA connection validation failed.");
         }
@@ -377,8 +378,7 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
                 group.getAdvisor() != null ? group.getAdvisor().getUserId() : null,
                 group.getStatus().name(),
                 group.getMembers().size(),
-                group.getCreatedAt()
-        );
+                group.getCreatedAt());
     }
 
     @Override
@@ -395,8 +395,7 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
                     member.getUser().getUserId(),
                     member.getUser().getStudentId(),
                     member.getUser().getFullName(),
-                    role
-            );
+                    role);
         }).collect(Collectors.toList());
     }
 
@@ -478,7 +477,7 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
     public List<AdvisorRequestResponseDto> getPendingAdvisorRequests(Long professorId) {
         List<Notification> requests = notificationRepository.findByToUser_UserIdAndTypeAndStatus(
                 professorId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING);
-                
+
         return requests.stream()
                 .filter(req -> req.getGroupId() != null)
                 .map(req -> {
@@ -496,10 +495,10 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
         Notification request = notificationRepository.findByGroupIdAndToUser_UserIdAndTypeAndStatus(
                 groupId, professorId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING)
                 .orElseThrow(() -> new BadRequestException("Pending advisor request not found for this group."));
-                
+
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new NotFoundException("Group not found."));
-                
+
         User professor = userRepository.findById(professorId)
                 .orElseThrow(() -> new NotFoundException("Professor not found."));
 
@@ -508,17 +507,35 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
             group.setStatus(GroupStatus.ADVISED);
             group.setUpdatedAt(Instant.now());
             groupRepository.save(group);
-            
+
             request.setStatus(NotificationStatus.ACCEPTED);
             notificationRepository.save(request);
-            
+
             List<Notification> otherRequests = notificationRepository.findByGroupIdAndTypeAndStatusAndToUser_UserIdNot(
                     groupId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING, professorId);
             for (Notification otherReq : otherRequests) {
                 otherReq.setStatus(NotificationStatus.REJECTED);
                 notificationRepository.save(otherReq);
+
+                Notification rejectNotif = new Notification();
+                rejectNotif.setType(NotificationType.SYSTEM_ALERT);
+                rejectNotif.setStatus(NotificationStatus.PENDING);
+                rejectNotif.setMessage("Your request to be advisor for group " + group.getGroupName()
+                        + " was automatically cancelled because they were assigned another advisor.");
+                rejectNotif.setGroupId(groupId);
+                rejectNotif.setToUser(otherReq.getToUser());
+                notificationRepository.save(rejectNotif);
+
+                AuditLog log = new AuditLog();
+                log.setActionType(ActionType.ADVISOR_REJECTED);
+                log.setUserId(professorId);
+                log.setGroupId(groupId);
+                log.setEventDetails(
+                        "Auto-rejected pending advisor request for professor " + otherReq.getToUser().getUserId() + " ("
+                                + otherReq.getToUser().getFullName() + ") due to approval of a different advisor.");
+                auditLogRepository.save(log);
             }
-            
+
             Notification notif = new Notification();
             notif.setType(NotificationType.ADVISOR_DECISION);
             notif.setStatus(NotificationStatus.PENDING);
@@ -531,7 +548,7 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
         } else if ("rejected".equalsIgnoreCase(status)) {
             request.setStatus(NotificationStatus.REJECTED);
             notificationRepository.save(request);
-            
+
             Notification notif = new Notification();
             notif.setType(NotificationType.ADVISOR_DECISION);
             notif.setStatus(NotificationStatus.PENDING);
@@ -552,13 +569,13 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
         if (!"coordinator".equalsIgnoreCase(requesterRole)) {
             throw new ForbiddenException("Only coordinators can transfer advisors.");
         }
-        
+
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new NotFoundException("Group not found."));
-                
+
         User professor = userRepository.findById(professorId)
                 .orElseThrow(() -> new NotFoundException("Professor not found."));
-                
+
         group.setAdvisor(professor);
         group.setStatus(GroupStatus.ADVISED);
         group.setUpdatedAt(Instant.now());
@@ -567,11 +584,12 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
         Notification notif = new Notification();
         notif.setType(NotificationType.SYSTEM_ALERT);
         notif.setStatus(NotificationStatus.PENDING);
-        notif.setMessage("You have been directly assigned as advisor to group: " + group.getGroupName() + " by the coordinator.");
+        notif.setMessage("You have been directly assigned as advisor to group: " + group.getGroupName()
+                + " by the coordinator.");
         notif.setGroupId(groupId);
         notif.setToUser(professor);
         notificationRepository.save(notif);
-        
+
         List<Notification> pendingRequests = notificationRepository.findByGroupIdAndTypeAndStatusAndToUser_UserIdNot(
                 groupId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING, -1L);
         for (Notification req : pendingRequests) {
@@ -586,27 +604,27 @@ public Page<GroupResponseDto> getGroups(Pageable pageable, Long requesterId, Str
         if (!"coordinator".equalsIgnoreCase(role)) {
             throw new ForbiddenException("Only coordinators can view group formation reports.");
         }
-        
+
         List<Group> allGroups = groupRepository.findAll();
         long totalGroups = allGroups.size();
-        
+
         long formedGroupsCnt = allGroups.stream()
                 .filter(g -> g.getStatus() == GroupStatus.FORMED || g.getStatus() == GroupStatus.ADVISED)
                 .count();
-                
+
         long unadvisedGroupsCnt = allGroups.stream()
                 .filter(g -> g.getAdvisor() == null && g.getStatus() != GroupStatus.DISBANDED)
                 .count();
-                
+
         List<GroupFormationReportDto.GroupStatusDetail> details = allGroups.stream()
                 .map(g -> new GroupFormationReportDto.GroupStatusDetail(
                         g.getId(),
                         g.getGroupName(),
                         g.getStatus().name(),
                         g.getAdvisor() != null ? g.getAdvisor().getUserId() : null,
-                        g.getAdvisor() != null ? g.getAdvisor().getFullName() : null
-                )).collect(Collectors.toList());
-                
+                        g.getAdvisor() != null ? g.getAdvisor().getFullName() : null))
+                .collect(Collectors.toList());
+
         return new GroupFormationReportDto(totalGroups, formedGroupsCnt, unadvisedGroupsCnt, details);
     }
 }

--- a/backend/src/test/java/com/spms/backend/controller/ProfessorControllerTest.java
+++ b/backend/src/test/java/com/spms/backend/controller/ProfessorControllerTest.java
@@ -8,6 +8,8 @@ import com.spms.backend.service.PasswordHashingService;
 import com.spms.backend.service.ProfessorRegistrationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import com.spms.backend.service.GroupService;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -19,103 +21,100 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 class ProfessorControllerTest {
 
-    private MockMvc mockMvc;
-    private ObjectMapper objectMapper;
+        private MockMvc mockMvc;
+        private ObjectMapper objectMapper;
 
-    @BeforeEach
-    void setUp() {
-        objectMapper = new ObjectMapper();
-        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
-        validator.afterPropertiesSet();
+        @BeforeEach
+        void setUp() {
+                objectMapper = new ObjectMapper();
+                LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+                validator.afterPropertiesSet();
 
-        ProfessorController professorController = new ProfessorController(
-                new ProfessorRegistrationService(new InMemoryUserRepository(), new PasswordHashingService())
-        );
+                ProfessorController professorController = new ProfessorController(
+                                new ProfessorRegistrationService(new InMemoryUserRepository(),
+                                                new PasswordHashingService()),
+                                Mockito.mock(GroupService.class));
 
-        mockMvc = MockMvcBuilders.standaloneSetup(professorController)
-                .setControllerAdvice(new GlobalExceptionHandler())
-                .setValidator(validator)
-                .build();
-    }
+                mockMvc = MockMvcBuilders.standaloneSetup(professorController)
+                                .setControllerAdvice(new GlobalExceptionHandler())
+                                .setValidator(validator)
+                                .build();
+        }
 
-    @Test
-    void registerProfessorReturns201WhenRequestIsValid() throws Exception {
-        ProfessorRegisterRequest request = new ProfessorRegisterRequest(
-                "Dr. Jane Doe",
-                "jane.doe@university.edu",
-                "SecurePass123!",
-                "professor"
-        );
+        @Test
+        void registerProfessorReturns201WhenRequestIsValid() throws Exception {
+                ProfessorRegisterRequest request = new ProfessorRegisterRequest(
+                                "Dr. Jane Doe",
+                                "jane.doe@university.edu",
+                                "SecurePass123!",
+                                "professor");
 
-        mockMvc.perform(post("/api/v1/professors/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.message").value("Professor registered successfully."))
-                .andExpect(jsonPath("$.userId").value(1))
-                .andExpect(jsonPath("$.role").value("professor"));
-    }
+                mockMvc.perform(post("/api/v1/professors/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$.message").value("Professor registered successfully."))
+                                .andExpect(jsonPath("$.userId").value(1))
+                                .andExpect(jsonPath("$.role").value("professor"));
+        }
 
-    @Test
-    void registerProfessorReturns400WhenEmailIsInvalid() throws Exception {
-        ProfessorRegisterRequest request = new ProfessorRegisterRequest(
-                "Dr. Jane Doe",
-                "not-an-email",
-                "SecurePass123!",
-                "professor"
-        );
+        @Test
+        void registerProfessorReturns400WhenEmailIsInvalid() throws Exception {
+                ProfessorRegisterRequest request = new ProfessorRegisterRequest(
+                                "Dr. Jane Doe",
+                                "not-an-email",
+                                "SecurePass123!",
+                                "professor");
 
-        mockMvc.perform(post("/api/v1/professors/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Bad Request"))
-                .andExpect(jsonPath("$.message").value("email must be a valid email address."));
-    }
+                mockMvc.perform(post("/api/v1/professors/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.error").value("Bad Request"))
+                                .andExpect(jsonPath("$.message").value("email must be a valid email address."));
+        }
 
-    @Test
-    void registerProfessorReturns400WhenRoleIsInvalid() throws Exception {
-        ProfessorRegisterRequest request = new ProfessorRegisterRequest(
-                "Dr. Jane Doe",
-                "jane.doe@university.edu",
-                "SecurePass123!",
-                "advisor"
-        );
+        @Test
+        void registerProfessorReturns400WhenRoleIsInvalid() throws Exception {
+                ProfessorRegisterRequest request = new ProfessorRegisterRequest(
+                                "Dr. Jane Doe",
+                                "jane.doe@university.edu",
+                                "SecurePass123!",
+                                "advisor");
 
-        mockMvc.perform(post("/api/v1/professors/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("Bad Request"))
-                .andExpect(jsonPath("$.message").value("role must be either professor or coordinator."));
-    }
+                mockMvc.perform(post("/api/v1/professors/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                                .andExpect(status().isBadRequest())
+                                .andExpect(jsonPath("$.error").value("Bad Request"))
+                                .andExpect(jsonPath("$.message")
+                                                .value("role must be either professor or coordinator."));
+        }
 
-    @Test
-    void registerProfessorReturns409WhenEmailAlreadyExists() throws Exception {
-        ProfessorRegisterRequest firstRequest = new ProfessorRegisterRequest(
-                "Dr. Jane Doe",
-                "jane.doe@university.edu",
-                "SecurePass123!",
-                "professor"
-        );
+        @Test
+        void registerProfessorReturns409WhenEmailAlreadyExists() throws Exception {
+                ProfessorRegisterRequest firstRequest = new ProfessorRegisterRequest(
+                                "Dr. Jane Doe",
+                                "jane.doe@university.edu",
+                                "SecurePass123!",
+                                "professor");
 
-        ProfessorRegisterRequest secondRequest = new ProfessorRegisterRequest(
-                "Dr. Jane Doe",
-                "JANE.DOE@UNIVERSITY.EDU",
-                "SecurePass123!",
-                "coordinator"
-        );
+                ProfessorRegisterRequest secondRequest = new ProfessorRegisterRequest(
+                                "Dr. Jane Doe",
+                                "JANE.DOE@UNIVERSITY.EDU",
+                                "SecurePass123!",
+                                "coordinator");
 
-        mockMvc.perform(post("/api/v1/professors/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(firstRequest)))
-                .andExpect(status().isCreated());
+                mockMvc.perform(post("/api/v1/professors/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(firstRequest)))
+                                .andExpect(status().isCreated());
 
-        mockMvc.perform(post("/api/v1/professors/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(secondRequest)))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.error").value("Conflict"))
-                .andExpect(jsonPath("$.message").value("A user already exists for the given email."));
-    }
+                mockMvc.perform(post("/api/v1/professors/register")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(secondRequest)))
+                                .andExpect(status().isConflict())
+                                .andExpect(jsonPath("$.error").value("Conflict"))
+                                .andExpect(jsonPath("$.message").value("A user already exists for the given email."));
+        }
 }

--- a/backend/src/test/java/com/spms/backend/service/GroupServiceImplJiraIntegrationTest.java
+++ b/backend/src/test/java/com/spms/backend/service/GroupServiceImplJiraIntegrationTest.java
@@ -16,6 +16,7 @@ import com.spms.backend.repository.GroupRepository;
 import com.spms.backend.repository.JiraIntegrationRepository;
 import com.spms.backend.repository.GithubIntegrationRepository;
 import com.spms.backend.repository.UserRepository;
+import com.spms.backend.repository.NotificationRepository;
 import com.spms.backend.service.impl.GroupServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,8 @@ class GroupServiceImplJiraIntegrationTest {
     @Mock
     private NotificationService notificationService;
     @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
     private AuditLogRepository auditLogRepository;
     @Mock
     private StudentAuthorizationService authService;
@@ -63,11 +66,12 @@ class GroupServiceImplJiraIntegrationTest {
                 groupMemberRepository,
                 userRepository,
                 notificationService,
-                auditLogRepository,
                 authService,
                 jiraIntegrationRepository,
                 githubIntegrationRepository,
-                jiraApiClient
+                jiraApiClient,
+                notificationRepository,
+                auditLogRepository
         );
     }
 


### PR DESCRIPTION
# PR Description: Auto-Reject Pending Advisor Requests (#33)

## Problem Summary
When a professor approves an advisor request for a group, any other pending requests from that same group to different professors remained stuck in the `PENDING` state. This created potential edge cases where a group could be approved by a second advisor later on improperly.

## What was Changed

### 1. Auto-Rejection Logic
- Modifed `GroupServiceImpl.handleAdvisorRequestDecision` to address the core requirement.
- When processing an `approved` decision, the system isolates all other strictly `PENDING` requests submitted by the newly-advised group. 
- All identified lingering requests are strictly shifted to the `REJECTED` state, preventing them from being falsely approved later (which otherwise throws a 400 Bad Request securely).

### 2. Notifications to Affected Professors
- Embedded a `SYSTEM_ALERT` notification dispatch whenever an advisor request is auto-rejected so the overlooked professor is cleanly informed that the group was assigned another advisor.

### 3. Granular Audit Trails
- As our audit log relies primarily on `@AuditableOperation` Aspects functioning at the highest-level method completion cycle, it would traditionally only log either `ADVISOR_APPROVED` or `ADVISOR_REJECTED` linearly once.
- We deliberately injected the `AuditLogRepository` to ensure that every individual explicit auto-rejection generated within the background loop creates a solid row mapped perfectly to `ActionType.ADVISOR_REJECTED`. 

### 4. Tests Fixed
- Resolved failing test compilations occurring in `GroupServiceImplJiraIntegrationTest.java` and `ProfessorControllerTest.java` where new constructor mock parameters were missing/out of sync from previous commits. Tests now effectively compile and pass `mvn clean compile` alongside application booting natively.

## Acceptance Criteria Met
- [x] On approval, all other pending requests for the same group are rejected.
- [x] Each auto-rejected professor receives a notification.
- [x] Auto-rejected requests cannot be approved later (returns 400).
- [x] If no other pending requests exist, no error occurs.
- [x] Audit log records each auto-rejection event.
- [x] Build and compile successfully (`mvn spring-boot:run` boots cleanly).
