### PR TITLE
feat: implement global user notifications API (#91)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/NotificationController.java
+++ b/backend/src/main/java/com/spms/backend/controller/NotificationController.java
@@ -106,11 +106,22 @@ public class NotificationController {
     @GetMapping("/api/v1/notifications")
     public ResponseEntity<Page<NotificationDto>> getUserNotifications(
             Pageable pageable,
+            @RequestParam(required = false, defaultValue = "ALL") String readStatus,
             @RequestAttribute("jwt_userId") Object userId) {
 
         Long currentUserId = Long.valueOf(userId.toString());
-        Page<NotificationDto> notifications = notificationService.getUserNotifications(currentUserId, pageable);
+        Page<NotificationDto> notifications = notificationService.getNotifications(currentUserId, readStatus, pageable);
         return ResponseEntity.ok(notifications);
+    }
+
+    @PatchMapping("/api/v1/notifications/{notificationId}/read")
+    public ResponseEntity<Void> markAsRead(
+            @PathVariable Long notificationId,
+            @RequestAttribute("jwt_userId") Object userId) {
+
+        Long currentUserId = Long.valueOf(userId.toString());
+        notificationService.markAsRead(notificationId, currentUserId);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/backend/src/main/java/com/spms/backend/controller/NotificationController.java
+++ b/backend/src/main/java/com/spms/backend/controller/NotificationController.java
@@ -6,6 +6,7 @@ import com.spms.backend.dto.request.NotificationRespondRequestDto;
 import com.spms.backend.dto.response.AdvisorRequestCreateResponseDto;
 import com.spms.backend.dto.response.AdvisorRequestStatusDto;
 import com.spms.backend.dto.response.NotificationDto;
+import com.spms.backend.dto.response.SuccessResponse;
 import com.spms.backend.exception.BadRequestException;
 import com.spms.backend.exception.ForbiddenException;
 import com.spms.backend.service.NotificationService;
@@ -115,13 +116,13 @@ public class NotificationController {
     }
 
     @PatchMapping("/api/v1/notifications/{notificationId}/read")
-    public ResponseEntity<Void> markAsRead(
+    public ResponseEntity<SuccessResponse> markAsRead(
             @PathVariable Long notificationId,
             @RequestAttribute("jwt_userId") Object userId) {
 
         Long currentUserId = Long.valueOf(userId.toString());
         notificationService.markAsRead(notificationId, currentUserId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new SuccessResponse("success", "Notification marked as read."));
     }
 
 

--- a/backend/src/main/java/com/spms/backend/dto/response/NotificationDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/NotificationDto.java
@@ -6,6 +6,7 @@ public record NotificationDto(
         String type,
         String message,
         String status,
+        boolean readStatus,
         Long fromUserId,
         String fromUserName,
         Long toUserId,

--- a/backend/src/main/java/com/spms/backend/dto/response/SuccessResponse.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/SuccessResponse.java
@@ -1,0 +1,6 @@
+package com.spms.backend.dto.response;
+
+public record SuccessResponse(
+        String status,
+        String message
+) {}

--- a/backend/src/main/java/com/spms/backend/model/notification/Notification.java
+++ b/backend/src/main/java/com/spms/backend/model/notification/Notification.java
@@ -42,6 +42,9 @@ public class Notification {
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt = Instant.now();
 
+    @Column(name = "read_status", nullable = false)
+    private boolean readStatus = false;
+
     public Long getId() {
         return id;
     }
@@ -104,5 +107,13 @@ public class Notification {
 
     public void setCreatedAt(Instant createdAt) {
         this.createdAt = createdAt;
+    }
+
+    public boolean isReadStatus() {
+        return readStatus;
+    }
+
+    public void setReadStatus(boolean readStatus) {
+        this.readStatus = readStatus;
     }
 }

--- a/backend/src/main/java/com/spms/backend/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/NotificationRepository.java
@@ -14,6 +14,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     Page<Notification> findByToUser_UserId(Long toUserId, Pageable pageable);
 
+    Page<Notification> findByToUser_UserIdAndReadStatus(Long toUserId, boolean readStatus, Pageable pageable);
+
     Optional<Notification> findByGroupIdAndTypeAndStatus(Long groupId, NotificationType type, NotificationStatus status);
 
     Optional<Notification> findByGroupIdAndToUser_UserIdAndTypeAndStatus(

--- a/backend/src/main/java/com/spms/backend/service/NotificationService.java
+++ b/backend/src/main/java/com/spms/backend/service/NotificationService.java
@@ -14,11 +14,16 @@ public interface NotificationService {
     void cancelAdvisorRequest(Long groupId);
     /** withdrawRequest / revokeNotification — sets notification status to REVOKED (soft-delete). */
     void withdrawAdvisorRequest(Long notificationId, Long requesterId);
-    Page<NotificationDto> getUserNotifications(Long userId, Pageable pageable);
+
+    /** Enhanced notification fetching with UNREAD/ALL filters. */
+    Page<NotificationDto> getNotifications(Long userId, String readStatus, Pageable pageable);
+
+    /** Sets readStatus = true. [PATCH /notifications/{id}/read] */
+    void markAsRead(Long notificationId, Long userId);
+
     void clearNotification(Long notificationId, Long userId);
     void clearAllNotifications(Long userId);
     void respondToNotification(Long notificationId, String decision, Long userId);
-    Page<NotificationDto> getSystemAlerts(Pageable pageable, String role);
     void sendGroupDisbandedNotification(Long groupId, Long actorUserId, String groupName, List<Long> memberIds);
     com.spms.backend.model.notification.Notification createSystemAlert(Long toUserId, String message, String alertType, String metadata);
     List<com.spms.backend.model.notification.Notification> getSystemAlertsByUserId(Long userId);

--- a/backend/src/main/java/com/spms/backend/service/impl/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/NotificationServiceImpl.java
@@ -174,7 +174,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
     /**
      * getNotifications (Enhanced Version)
-     * Supports filtering by UNREAD (readStatus=false) or ALL.
+     * Supports filtering by UNREAD (readStatus=false), READ (readStatus=true), or ALL.
      */
     @Override
     @Transactional(readOnly = true)
@@ -183,11 +183,15 @@ public class NotificationServiceImpl implements NotificationService {
             return notificationRepository.findByToUser_UserIdAndReadStatus(userId, false, pageable)
                     .map(this::mapToDto);
         }
+        if ("READ".equalsIgnoreCase(readStatus)) {
+            return notificationRepository.findByToUser_UserIdAndReadStatus(userId, true, pageable)
+                    .map(this::mapToDto);
+        }
         if ("ALL".equalsIgnoreCase(readStatus)) {
             return notificationRepository.findByToUser_UserId(userId, pageable)
                     .map(this::mapToDto);
         }
-        throw new BadRequestException("Invalid readStatus. Supported values: UNREAD or ALL.");
+        throw new BadRequestException("Invalid readStatus. Supported values: UNREAD, READ, or ALL.");
     }
 
     /**
@@ -200,7 +204,7 @@ public class NotificationServiceImpl implements NotificationService {
                 .orElseThrow(() -> new NotFoundException("Notification not found."));
 
         if (!notification.getToUser().getUserId().equals(userId)) {
-            throw new UnauthorizedException("You are not authorized to access this notification.");
+            throw new ForbiddenException("You are not authorized to access this notification.");
         }
 
         notification.setReadStatus(true);

--- a/backend/src/main/java/com/spms/backend/service/impl/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/NotificationServiceImpl.java
@@ -141,7 +141,6 @@ public class NotificationServiceImpl implements NotificationService {
         request.setStatus(NotificationStatus.CLEARED);
         notificationRepository.save(request);
 
-        // log_f2 – P2.9 audit: advisor request cancelled
         log.info("[AUDIT] cancelAdvisorRequest: groupId={} notificationId={} newStatus=CLEARED",
                 groupId, request.getId());
     }
@@ -173,13 +172,39 @@ public class NotificationServiceImpl implements NotificationService {
         notification.setStatus(NotificationStatus.REVOKED);
         notificationRepository.save(notification);
     }
-
-
+    /**
+     * getNotifications (Enhanced Version)
+     * Supports filtering by UNREAD (readStatus=false) or ALL.
+     */
     @Override
     @Transactional(readOnly = true)
-    public Page<NotificationDto> getUserNotifications(Long userId, Pageable pageable) {
-        return notificationRepository.findByToUser_UserId(userId, pageable)
-                .map(this::mapToDto);
+    public Page<NotificationDto> getNotifications(Long userId, String readStatus, Pageable pageable) {
+        if ("UNREAD".equalsIgnoreCase(readStatus)) {
+            return notificationRepository.findByToUser_UserIdAndReadStatus(userId, false, pageable)
+                    .map(this::mapToDto);
+        }
+        if ("ALL".equalsIgnoreCase(readStatus)) {
+            return notificationRepository.findByToUser_UserId(userId, pageable)
+                    .map(this::mapToDto);
+        }
+        throw new BadRequestException("Invalid readStatus. Supported values: UNREAD or ALL.");
+    }
+
+    /**
+     * markAsRead (PATCH /notifications/{id}/read)
+     */
+    @Override
+    @Transactional
+    public void markAsRead(Long notificationId, Long userId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotFoundException("Notification not found."));
+
+        if (!notification.getToUser().getUserId().equals(userId)) {
+            throw new UnauthorizedException("You are not authorized to access this notification.");
+        }
+
+        notification.setReadStatus(true);
+        notificationRepository.save(notification);
     }
 
     @Override
@@ -231,15 +256,6 @@ public class NotificationServiceImpl implements NotificationService {
         }
 
         notificationRepository.save(notification);
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public Page<NotificationDto> getSystemAlerts(Pageable pageable, String role) {
-        if (!"COORDINATOR".equalsIgnoreCase(role)) {
-            throw new UnauthorizedException("You are not authorized to view system alerts! Required role: COORDINATOR.");
-        }
-        return Page.empty(pageable);
     }
 
     @Override
@@ -298,6 +314,7 @@ public class NotificationServiceImpl implements NotificationService {
                 notif.getType().name().toLowerCase(),
                 notif.getMessage(),
                 notif.getStatus().name().toLowerCase(),
+                notif.isReadStatus(),
                 notif.getFromUser() != null ? notif.getFromUser().getUserId() : null,
                 notif.getFromUser() != null ? notif.getFromUser().getFullName() : null,
                 notif.getToUser() != null ? notif.getToUser().getUserId() : null,

--- a/backend/src/test/java/com/spms/backend/service/AdvisorRequestDetailServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/AdvisorRequestDetailServiceTest.java
@@ -217,6 +217,7 @@ class AdvisorRequestDetailServiceTest {
         @Override public void deleteAll() { store.clear(); }
 
         @Override public Page<Notification> findByToUser_UserId(Long toUserId, Pageable pageable) { return Page.empty(); }
+        @Override public Page<Notification> findByToUser_UserIdAndReadStatus(Long toUserId, boolean readStatus, Pageable pageable) { return Page.empty(); }
         @Override public Optional<Notification> findByGroupIdAndTypeAndStatus(Long groupId, NotificationType type, com.spms.backend.model.notification.NotificationStatus status) { return Optional.empty(); }
         @Override public Optional<Notification> findByGroupIdAndToUser_UserIdAndTypeAndStatus(Long groupId, Long toUserId, NotificationType type, com.spms.backend.model.notification.NotificationStatus status) { return Optional.empty(); }
         @Override public void deleteByToUser_UserId(Long userId) {}

--- a/backend/src/test/java/com/spms/backend/service/NotificationServiceIssue91Test.java
+++ b/backend/src/test/java/com/spms/backend/service/NotificationServiceIssue91Test.java
@@ -2,8 +2,8 @@ package com.spms.backend.service;
 
 import com.spms.backend.dto.response.NotificationDto;
 import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.exception.ForbiddenException;
 import com.spms.backend.exception.NotFoundException;
-import com.spms.backend.exception.UnauthorizedException;
 import com.spms.backend.model.User;
 import com.spms.backend.model.notification.Notification;
 import com.spms.backend.model.notification.NotificationStatus;
@@ -62,6 +62,19 @@ class NotificationServiceIssue91Test {
     }
 
     @Test
+    void getNotificationsReturnsReadWhenReadStatusRead() {
+        Notification notification = buildNotification(16L, 100L);
+        notification.setReadStatus(true);
+        when(notificationRepository.findByToUser_UserIdAndReadStatus(100L, true, pageable))
+                .thenReturn(new PageImpl<>(List.of(notification)));
+
+        Page<NotificationDto> result = notificationService.getNotifications(100L, "READ", pageable);
+
+        assertEquals(1, result.getTotalElements());
+        verify(notificationRepository).findByToUser_UserIdAndReadStatus(100L, true, pageable);
+    }
+
+    @Test
     void getNotificationsRejectsInvalidReadStatus() {
         assertThrows(
                 BadRequestException.class,
@@ -87,7 +100,7 @@ class NotificationServiceIssue91Test {
         when(notificationRepository.findById(22L)).thenReturn(Optional.of(notification));
 
         assertThrows(
-                UnauthorizedException.class,
+                ForbiddenException.class,
                 () -> notificationService.markAsRead(22L, 999L)
         );
     }

--- a/backend/src/test/java/com/spms/backend/service/NotificationServiceIssue91Test.java
+++ b/backend/src/test/java/com/spms/backend/service/NotificationServiceIssue91Test.java
@@ -1,0 +1,117 @@
+package com.spms.backend.service;
+
+import com.spms.backend.dto.response.NotificationDto;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.exception.NotFoundException;
+import com.spms.backend.exception.UnauthorizedException;
+import com.spms.backend.model.User;
+import com.spms.backend.model.notification.Notification;
+import com.spms.backend.model.notification.NotificationStatus;
+import com.spms.backend.model.notification.NotificationType;
+import com.spms.backend.repository.NotificationRepository;
+import com.spms.backend.repository.UserRepository;
+import com.spms.backend.service.impl.NotificationServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceIssue91Test {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MemberService memberService;
+
+    private NotificationServiceImpl notificationService;
+    private Pageable pageable;
+
+    @BeforeEach
+    void setUp() {
+        notificationService = new NotificationServiceImpl(notificationRepository, userRepository, memberService);
+        pageable = PageRequest.of(0, 10);
+    }
+
+    @Test
+    void getNotificationsReturnsUnreadWhenReadStatusUnread() {
+        Notification notification = buildNotification(15L, 100L);
+        when(notificationRepository.findByToUser_UserIdAndReadStatus(100L, false, pageable))
+                .thenReturn(new PageImpl<>(List.of(notification)));
+
+        Page<NotificationDto> result = notificationService.getNotifications(100L, "UNREAD", pageable);
+
+        assertEquals(1, result.getTotalElements());
+        verify(notificationRepository).findByToUser_UserIdAndReadStatus(100L, false, pageable);
+    }
+
+    @Test
+    void getNotificationsRejectsInvalidReadStatus() {
+        assertThrows(
+                BadRequestException.class,
+                () -> notificationService.getNotifications(100L, "NEW_ONLY", pageable)
+        );
+    }
+
+    @Test
+    void markAsReadUpdatesReadStatusForRecipientOnly() {
+        Notification notification = buildNotification(22L, 100L);
+        when(notificationRepository.findById(22L)).thenReturn(Optional.of(notification));
+
+        notificationService.markAsRead(22L, 100L);
+
+        ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationRepository).save(captor.capture());
+        assertEquals(true, captor.getValue().isReadStatus());
+    }
+
+    @Test
+    void markAsReadRejectsOtherRecipients() {
+        Notification notification = buildNotification(22L, 100L);
+        when(notificationRepository.findById(22L)).thenReturn(Optional.of(notification));
+
+        assertThrows(
+                UnauthorizedException.class,
+                () -> notificationService.markAsRead(22L, 999L)
+        );
+    }
+
+    @Test
+    void markAsReadThrowsNotFoundWhenNotificationMissing() {
+        when(notificationRepository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThrows(
+                NotFoundException.class,
+                () -> notificationService.markAsRead(404L, 100L)
+        );
+    }
+
+    private Notification buildNotification(Long notificationId, Long recipientId) {
+        User recipient = new User();
+        recipient.setUserId(recipientId);
+
+        Notification notification = new Notification();
+        notification.setId(notificationId);
+        notification.setType(NotificationType.SYSTEM_ALERT);
+        notification.setStatus(NotificationStatus.PENDING);
+        notification.setMessage("system alert");
+        notification.setToUser(recipient);
+        return notification;
+    }
+}


### PR DESCRIPTION
Notification Retrieval: Implemented GET /notifications allowing users to fetch their system notifications. Added filtering support for status=UNREAD or ALL.

Security & Data Isolation: Enforced strict authorization so a user can ONLY retrieve and view notifications where they are the designated recipient.

Read Status Management: Added the PATCH /notifications/{notificationId}/read endpoint to successfully update a notification's readStatus to true.

Member Management Integration: Ensured that NotificationServiceImpl correctly handles MEMBERSHIP_INVITE acceptances by cleanly invoking memberService.addMember.

Cleanup: Resolved merge conflicts with the latest main branch and removed outdated/hallucinated auditing logic.

Verification
Retrieval & Filtering: Verified that users can successfully fetch their notifications and that the UNREAD/ALL filters work as expected.

Security Check: Confirmed that users receive a 403 Forbidden (or empty list) if attempting to access another user's notifications.

Status Update: Verified the PATCH endpoint correctly sets readStatus = true in the database.