### PR TITLE
feat: add grading criteria management API (Resolves #153)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/GradingCriteriaController.java
+++ b/backend/src/main/java/com/spms/backend/controller/GradingCriteriaController.java
@@ -1,0 +1,50 @@
+package com.spms.backend.controller;
+
+import com.spms.backend.dto.request.GradingCriteriaCreateRequestDto;
+import com.spms.backend.dto.response.GradingCriteriaDto;
+import com.spms.backend.service.GradingCriteriaService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/grading-criteria")
+public class GradingCriteriaController {
+
+    private final GradingCriteriaService gradingCriteriaService;
+
+    public GradingCriteriaController(GradingCriteriaService gradingCriteriaService) {
+        this.gradingCriteriaService = gradingCriteriaService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, Object>> createCriteria(
+            @Valid @RequestBody GradingCriteriaCreateRequestDto request,
+            @RequestAttribute("jwt_userId") Object userId) {
+
+        Long creatorId = Long.valueOf(userId.toString());
+        GradingCriteriaDto created = gradingCriteriaService.create(request, creatorId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of(
+                "status", "success",
+                "message", "Grading criteria created successfully.",
+                "data", created
+        ));
+    }
+
+    @GetMapping
+    public ResponseEntity<Map<String, Object>> listCriteria(
+            @RequestParam(required = false) String deliverableType) {
+
+        List<GradingCriteriaDto> criteria = gradingCriteriaService.list(deliverableType);
+
+        return ResponseEntity.ok(Map.of(
+                "status", "success",
+                "data", criteria
+        ));
+    }
+}

--- a/backend/src/main/java/com/spms/backend/controller/GradingCriteriaController.java
+++ b/backend/src/main/java/com/spms/backend/controller/GradingCriteriaController.java
@@ -2,6 +2,7 @@ package com.spms.backend.controller;
 
 import com.spms.backend.dto.request.GradingCriteriaCreateRequestDto;
 import com.spms.backend.dto.response.GradingCriteriaDto;
+import com.spms.backend.exception.ForbiddenException;
 import com.spms.backend.service.GradingCriteriaService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -24,7 +25,12 @@ public class GradingCriteriaController {
     @PostMapping
     public ResponseEntity<Map<String, Object>> createCriteria(
             @Valid @RequestBody GradingCriteriaCreateRequestDto request,
-            @RequestAttribute("jwt_userId") Object userId) {
+            @RequestAttribute("jwt_userId") Object userId,
+            @RequestAttribute("jwt_role") Object role) {
+
+        if (!"coordinator".equals(role)) {
+            throw new ForbiddenException("Only coordinators can create grading criteria.");
+        }
 
         Long creatorId = Long.valueOf(userId.toString());
         GradingCriteriaDto created = gradingCriteriaService.create(request, creatorId);

--- a/backend/src/main/java/com/spms/backend/dto/request/GradingCriteriaCreateRequestDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/GradingCriteriaCreateRequestDto.java
@@ -1,0 +1,19 @@
+package com.spms.backend.dto.request;
+
+import jakarta.validation.constraints.*;
+
+public record GradingCriteriaCreateRequestDto(
+        @NotBlank(message = "deliverableType is required")
+        String deliverableType,
+
+        @NotBlank(message = "name is required")
+        @Size(max = 255, message = "name must be at most 255 characters")
+        String name,
+
+        String description,
+
+        @NotNull(message = "weight is required")
+        @DecimalMin(value = "0.0", message = "weight must be >= 0")
+        @DecimalMax(value = "100.0", message = "weight must be <= 100")
+        Double weight
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/GradingCriteriaDto.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/GradingCriteriaDto.java
@@ -1,0 +1,9 @@
+package com.spms.backend.dto.response;
+
+public record GradingCriteriaDto(
+        Long id,
+        String deliverableType,
+        String name,
+        String description,
+        Double weight
+) {}

--- a/backend/src/main/java/com/spms/backend/model/DeliverableType.java
+++ b/backend/src/main/java/com/spms/backend/model/DeliverableType.java
@@ -1,0 +1,7 @@
+package com.spms.backend.model;
+
+public enum DeliverableType {
+    PROPOSAL,
+    REVISED_PROPOSAL,
+    STATEMENT_OF_WORK
+}

--- a/backend/src/main/java/com/spms/backend/model/DeliverableTypeConverter.java
+++ b/backend/src/main/java/com/spms/backend/model/DeliverableTypeConverter.java
@@ -1,0 +1,19 @@
+package com.spms.backend.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Locale;
+
+@Converter(autoApply = false)
+public class DeliverableTypeConverter implements AttributeConverter<DeliverableType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(DeliverableType attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public DeliverableType convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : DeliverableType.valueOf(dbData.toUpperCase(Locale.ROOT));
+    }
+}

--- a/backend/src/main/java/com/spms/backend/model/GradingCriteria.java
+++ b/backend/src/main/java/com/spms/backend/model/GradingCriteria.java
@@ -1,0 +1,58 @@
+package com.spms.backend.model;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "grading_criteria")
+public class GradingCriteria {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "deliverable_type", nullable = false, length = 50)
+    @Convert(converter = DeliverableTypeConverter.class)
+    private DeliverableType deliverableType;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "weight", nullable = false)
+    private Double weight;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "created_by", nullable = false)
+    private Long createdBy;
+
+    @PrePersist
+    void onCreate() {
+        createdAt = Instant.now();
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public DeliverableType getDeliverableType() { return deliverableType; }
+    public void setDeliverableType(DeliverableType deliverableType) { this.deliverableType = deliverableType; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public Double getWeight() { return weight; }
+    public void setWeight(Double weight) { this.weight = weight; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Long getCreatedBy() { return createdBy; }
+    public void setCreatedBy(Long createdBy) { this.createdBy = createdBy; }
+}

--- a/backend/src/main/java/com/spms/backend/repository/GradingCriteriaRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/GradingCriteriaRepository.java
@@ -1,0 +1,12 @@
+package com.spms.backend.repository;
+
+import com.spms.backend.model.DeliverableType;
+import com.spms.backend.model.GradingCriteria;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface GradingCriteriaRepository extends JpaRepository<GradingCriteria, Long> {
+
+    List<GradingCriteria> findByDeliverableType(DeliverableType deliverableType);
+}

--- a/backend/src/main/java/com/spms/backend/service/GradingCriteriaService.java
+++ b/backend/src/main/java/com/spms/backend/service/GradingCriteriaService.java
@@ -9,6 +9,7 @@ import com.spms.backend.exception.ForbiddenException;
 import com.spms.backend.repository.GradingCriteriaRepository;
 import com.spms.backend.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,6 +26,7 @@ public class GradingCriteriaService {
         this.userRepository = userRepository;
     }
 
+    @Transactional
     public GradingCriteriaDto create(GradingCriteriaCreateRequestDto request, Long creatorId) {
         var user = userRepository.findByUserId(creatorId)
                 .orElseThrow(() -> new BadRequestException("User not found."));
@@ -46,6 +48,7 @@ public class GradingCriteriaService {
         return toDto(saved);
     }
 
+    @Transactional(readOnly = true)
     public List<GradingCriteriaDto> list(String deliverableTypeParam) {
         if (deliverableTypeParam == null || deliverableTypeParam.isBlank()) {
             return criteriaRepository.findAll().stream()

--- a/backend/src/main/java/com/spms/backend/service/GradingCriteriaService.java
+++ b/backend/src/main/java/com/spms/backend/service/GradingCriteriaService.java
@@ -1,0 +1,80 @@
+package com.spms.backend.service;
+
+import com.spms.backend.dto.request.GradingCriteriaCreateRequestDto;
+import com.spms.backend.dto.response.GradingCriteriaDto;
+import com.spms.backend.model.DeliverableType;
+import com.spms.backend.model.GradingCriteria;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.exception.ForbiddenException;
+import com.spms.backend.repository.GradingCriteriaRepository;
+import com.spms.backend.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class GradingCriteriaService {
+
+    private final GradingCriteriaRepository criteriaRepository;
+    private final UserRepository userRepository;
+
+    public GradingCriteriaService(GradingCriteriaRepository criteriaRepository,
+                                   UserRepository userRepository) {
+        this.criteriaRepository = criteriaRepository;
+        this.userRepository = userRepository;
+    }
+
+    public GradingCriteriaDto create(GradingCriteriaCreateRequestDto request, Long creatorId) {
+        var user = userRepository.findByUserId(creatorId)
+                .orElseThrow(() -> new BadRequestException("User not found."));
+
+        if (!"coordinator".equalsIgnoreCase(user.getRole())) {
+            throw new ForbiddenException("Only coordinators can define grading criteria.");
+        }
+
+        DeliverableType deliverableType = parseDeliverableType(request.deliverableType());
+
+        GradingCriteria criteria = new GradingCriteria();
+        criteria.setDeliverableType(deliverableType);
+        criteria.setName(request.name());
+        criteria.setDescription(request.description());
+        criteria.setWeight(request.weight());
+        criteria.setCreatedBy(creatorId);
+
+        GradingCriteria saved = criteriaRepository.save(criteria);
+        return toDto(saved);
+    }
+
+    public List<GradingCriteriaDto> list(String deliverableTypeParam) {
+        if (deliverableTypeParam == null || deliverableTypeParam.isBlank()) {
+            return criteriaRepository.findAll().stream()
+                    .map(this::toDto)
+                    .collect(Collectors.toList());
+        }
+
+        DeliverableType deliverableType = parseDeliverableType(deliverableTypeParam);
+        return criteriaRepository.findByDeliverableType(deliverableType).stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+
+    private DeliverableType parseDeliverableType(String value) {
+        try {
+            return DeliverableType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid deliverableType: " + value +
+                    ". Must be one of: PROPOSAL, REVISED_PROPOSAL, STATEMENT_OF_WORK");
+        }
+    }
+
+    private GradingCriteriaDto toDto(GradingCriteria c) {
+        return new GradingCriteriaDto(
+                c.getId(),
+                c.getDeliverableType().name(),
+                c.getName(),
+                c.getDescription(),
+                c.getWeight()
+        );
+    }
+}

--- a/backend/src/main/java/com/spms/backend/service/GradingCriteriaService.java
+++ b/backend/src/main/java/com/spms/backend/service/GradingCriteriaService.java
@@ -5,9 +5,7 @@ import com.spms.backend.dto.response.GradingCriteriaDto;
 import com.spms.backend.model.DeliverableType;
 import com.spms.backend.model.GradingCriteria;
 import com.spms.backend.exception.BadRequestException;
-import com.spms.backend.exception.ForbiddenException;
 import com.spms.backend.repository.GradingCriteriaRepository;
-import com.spms.backend.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,23 +16,13 @@ import java.util.stream.Collectors;
 public class GradingCriteriaService {
 
     private final GradingCriteriaRepository criteriaRepository;
-    private final UserRepository userRepository;
 
-    public GradingCriteriaService(GradingCriteriaRepository criteriaRepository,
-                                   UserRepository userRepository) {
+    public GradingCriteriaService(GradingCriteriaRepository criteriaRepository) {
         this.criteriaRepository = criteriaRepository;
-        this.userRepository = userRepository;
     }
 
     @Transactional
     public GradingCriteriaDto create(GradingCriteriaCreateRequestDto request, Long creatorId) {
-        var user = userRepository.findByUserId(creatorId)
-                .orElseThrow(() -> new BadRequestException("User not found."));
-
-        if (!"coordinator".equalsIgnoreCase(user.getRole())) {
-            throw new ForbiddenException("Only coordinators can define grading criteria.");
-        }
-
         DeliverableType deliverableType = parseDeliverableType(request.deliverableType());
 
         GradingCriteria criteria = new GradingCriteria();

--- a/backend/src/test/java/com/spms/api/GradingCriteriaApiTest.java
+++ b/backend/src/test/java/com/spms/api/GradingCriteriaApiTest.java
@@ -1,0 +1,200 @@
+package com.spms.api;
+
+import com.spms.backend.model.User;
+import com.spms.backend.repository.GradingCriteriaRepository;
+import com.spms.backend.repository.UserRepository;
+import com.spms.backend.service.TokenService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * API tests for POST /api/v1/grading-criteria and GET /api/v1/grading-criteria.
+ * Covers P3-CRITERIA-1: Coordinator-only create + filtered list.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class GradingCriteriaApiTest extends BaseApiTest {
+
+    private static final AtomicLong SEQ = new AtomicLong(System.currentTimeMillis());
+
+    @Autowired private TokenService tokenService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private GradingCriteriaRepository gradingCriteriaRepository;
+
+    private String coordinatorToken;
+    private String professorToken;
+    private String studentToken;
+
+    private Long coordinatorUserId;
+    private Long professorUserId;
+    private Long studentUserId;
+
+    @BeforeAll
+    void seedUsers() {
+        User coordinator = createUser("coordinator");
+        User professor   = createUser("professor");
+        User student     = createUser("student");
+
+        coordinatorUserId = coordinator.getUserId();
+        professorUserId   = professor.getUserId();
+        studentUserId     = student.getUserId();
+
+        coordinatorToken = tokenService.generateToken(coordinator);
+        professorToken   = tokenService.generateToken(professor);
+        studentToken     = tokenService.generateToken(student);
+    }
+
+    @AfterAll
+    void cleanupTestData() {
+        gradingCriteriaRepository.deleteAll();
+
+        deleteUserSafely(coordinatorUserId, "Coordinator");
+        deleteUserSafely(professorUserId,   "Professor");
+        deleteUserSafely(studentUserId,     "Student");
+    }
+
+    private void deleteUserSafely(Long userId, String label) {
+        if (userId == null) return;
+        userRepository.findByUserId(userId).ifPresentOrElse(
+            u -> {
+                userRepository.delete(u);
+                System.out.println("  " + label + " user deleted: userId=" + userId);
+            },
+            () -> System.err.println("  [CLEANUP] " + label + " user not found: userId=" + userId)
+        );
+    }
+
+    private User createUser(String role) {
+        long seq = SEQ.incrementAndGet();
+        User user = new User();
+        user.setFullName("Test " + role + " " + seq);
+        user.setEmail("criteria-" + role + "-" + seq + "@spms-test.com");
+        user.setRole(role);
+        user.setPasswordHash("pbkdf2$65536$dummySalt$dummyHash");
+        user.setRequiresPasswordChange(false);
+        user.setCreatedAt(Instant.now());
+        if ("student".equals(role)) {
+            user.setStudentId(String.format("99%09d", seq % 1_000_000_000));
+        }
+        return userRepository.save(user);
+    }
+
+    // ── POST /api/v1/grading-criteria ────────────────────────────────
+
+    @Test
+    @Order(1)
+    void postAsCoordinator_returns201() {
+        given()
+            .header("Authorization", "Bearer " + coordinatorToken)
+            .body(Map.of(
+                "deliverableType", "PROPOSAL",
+                "name", "Technical Feasibility",
+                "description", "Evaluate technical feasibility",
+                "weight", 30.0
+            ))
+        .when()
+            .post("/api/v1/grading-criteria")
+        .then()
+            .statusCode(201)
+            .body("status", equalTo("success"))
+            .body("data.id", notNullValue())
+            .body("data.deliverableType", equalTo("PROPOSAL"))
+            .body("data.name", equalTo("Technical Feasibility"))
+            .body("data.weight", equalTo(30.0f));
+    }
+
+    @Test
+    @Order(2)
+    void postAsProfessor_returns403() {
+        given()
+            .header("Authorization", "Bearer " + professorToken)
+            .body(Map.of(
+                "deliverableType", "PROPOSAL",
+                "name", "Clarity",
+                "weight", 20.0
+            ))
+        .when()
+            .post("/api/v1/grading-criteria")
+        .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @Order(3)
+    void postAsStudent_returns403() {
+        given()
+            .header("Authorization", "Bearer " + studentToken)
+            .body(Map.of(
+                "deliverableType", "PROPOSAL",
+                "name", "Clarity",
+                "weight", 20.0
+            ))
+        .when()
+            .post("/api/v1/grading-criteria")
+        .then()
+            .statusCode(403);
+    }
+
+    @Test
+    @Order(4)
+    void postWithInvalidDeliverableType_returns400() {
+        given()
+            .header("Authorization", "Bearer " + coordinatorToken)
+            .body(Map.of(
+                "deliverableType", "BOGUS_TYPE",
+                "name", "Some Criteria",
+                "weight", 10.0
+            ))
+        .when()
+            .post("/api/v1/grading-criteria")
+        .then()
+            .statusCode(400);
+    }
+
+    // ── GET /api/v1/grading-criteria ─────────────────────────────────
+
+    @Test
+    @Order(5)
+    void getWithoutFilter_returns200WithList() {
+        // Seed a SOW criterion so we have data across types
+        given()
+            .header("Authorization", "Bearer " + coordinatorToken)
+            .body(Map.of(
+                "deliverableType", "STATEMENT_OF_WORK",
+                "name", "Implementation Plan",
+                "weight", 40.0
+            ))
+        .when()
+            .post("/api/v1/grading-criteria");
+
+        given()
+            .header("Authorization", "Bearer " + coordinatorToken)
+        .when()
+            .get("/api/v1/grading-criteria")
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("success"))
+            .body("data", hasSize(greaterThanOrEqualTo(1)));
+    }
+
+    @Test
+    @Order(6)
+    void getWithDeliverableTypeFilter_returnsOnlyMatchingType() {
+        given()
+            .header("Authorization", "Bearer " + coordinatorToken)
+            .queryParam("deliverableType", "PROPOSAL")
+        .when()
+            .get("/api/v1/grading-criteria")
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("success"))
+            .body("data", everyItem(hasEntry("deliverableType", "PROPOSAL")));
+    }
+}

--- a/backend/src/test/java/com/spms/backend/repository/InMemoryGradingCriteriaRepository.java
+++ b/backend/src/test/java/com/spms/backend/repository/InMemoryGradingCriteriaRepository.java
@@ -1,0 +1,87 @@
+package com.spms.backend.repository;
+
+import com.spms.backend.model.DeliverableType;
+import com.spms.backend.model.GradingCriteria;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+public class InMemoryGradingCriteriaRepository
+        extends AbstractStubJpaRepository<GradingCriteria, Long>
+        implements GradingCriteriaRepository {
+
+    private final Map<Long, GradingCriteria> store = new ConcurrentHashMap<>();
+    private final AtomicLong idSequence = new AtomicLong(1L);
+
+    @Override
+    public <S extends GradingCriteria> S save(S entity) {
+        if (entity.getId() == null) {
+            entity.setId(idSequence.getAndIncrement());
+        }
+        store.put(entity.getId(), entity);
+        return entity;
+    }
+
+    @Override
+    public Optional<GradingCriteria> findById(Long id) {
+        return Optional.ofNullable(store.get(id));
+    }
+
+    @Override
+    public List<GradingCriteria> findAll() {
+        return new ArrayList<>(store.values());
+    }
+
+    @Override
+    public List<GradingCriteria> findByDeliverableType(DeliverableType deliverableType) {
+        return store.values().stream()
+                .filter(c -> c.getDeliverableType() == deliverableType)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        store.remove(id);
+    }
+
+    @Override
+    public void delete(GradingCriteria entity) {
+        if (entity.getId() != null) store.remove(entity.getId());
+    }
+
+    @Override
+    public void deleteAll() {
+        store.clear();
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return store.containsKey(id);
+    }
+
+    @Override
+    public long count() {
+        return store.size();
+    }
+
+    @Override
+    public <S extends GradingCriteria> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        entities.forEach(e -> result.add(save(e)));
+        return result;
+    }
+
+    @Override
+    public List<GradingCriteria> findAllById(Iterable<Long> ids) {
+        List<GradingCriteria> result = new ArrayList<>();
+        ids.forEach(id -> findById(id).ifPresent(result::add));
+        return result;
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> ids) {
+        ids.forEach(store::remove);
+    }
+}

--- a/backend/src/test/java/com/spms/backend/service/GradingCriteriaServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/GradingCriteriaServiceTest.java
@@ -1,0 +1,119 @@
+package com.spms.backend.service;
+
+import com.spms.backend.dto.request.GradingCriteriaCreateRequestDto;
+import com.spms.backend.dto.response.GradingCriteriaDto;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.exception.ForbiddenException;
+import com.spms.backend.model.User;
+import com.spms.backend.repository.InMemoryGradingCriteriaRepository;
+import com.spms.backend.repository.InMemoryUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GradingCriteriaServiceTest {
+
+    private InMemoryUserRepository userRepository;
+    private InMemoryGradingCriteriaRepository criteriaRepository;
+    private GradingCriteriaService service;
+
+    private User coordinator;
+    private User professor;
+    private User student;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = new InMemoryUserRepository();
+        criteriaRepository = new InMemoryGradingCriteriaRepository();
+        service = new GradingCriteriaService(criteriaRepository, userRepository);
+
+        coordinator = makeUser("coordinator");
+        professor = makeUser("professor");
+        student = makeUser("student");
+    }
+
+    private User makeUser(String role) {
+        User u = new User();
+        u.setFullName("Test " + role);
+        u.setEmail(role + "@test.com");
+        u.setRole(role);
+        u.setCreatedAt(Instant.now());
+        if ("student".equals(role)) {
+            u.setStudentId("1234567890" + role.length());
+        } else {
+            u.setPasswordHash("pbkdf2$65536$salt$hash");
+            u.setRequiresPasswordChange(false);
+        }
+        return userRepository.save(u);
+    }
+
+    // ── create ──────────────────────────────────────────────────────────
+
+    @Test
+    void createAsCoordinator_succeeds() {
+        var req = new GradingCriteriaCreateRequestDto("PROPOSAL", "Technical Feasibility", "Desc", 30.0);
+        GradingCriteriaDto dto = service.create(req, coordinator.getUserId());
+
+        assertNotNull(dto.id());
+        assertEquals("PROPOSAL", dto.deliverableType());
+        assertEquals("Technical Feasibility", dto.name());
+        assertEquals("Desc", dto.description());
+        assertEquals(30.0, dto.weight());
+    }
+
+    @Test
+    void createAsProfessor_throwsForbidden() {
+        var req = new GradingCriteriaCreateRequestDto("PROPOSAL", "Clarity", null, 20.0);
+        assertThrows(ForbiddenException.class, () -> service.create(req, professor.getUserId()));
+    }
+
+    @Test
+    void createAsStudent_throwsForbidden() {
+        var req = new GradingCriteriaCreateRequestDto("PROPOSAL", "Clarity", null, 20.0);
+        assertThrows(ForbiddenException.class, () -> service.create(req, student.getUserId()));
+    }
+
+    @Test
+    void createWithInvalidDeliverableType_throwsBadRequest() {
+        var req = new GradingCriteriaCreateRequestDto("INVALID_TYPE", "Name", null, 10.0);
+        assertThrows(BadRequestException.class, () -> service.create(req, coordinator.getUserId()));
+    }
+
+    // ── list ─────────────────────────────────────────────────────────────
+
+    @Test
+    void listWithoutFilter_returnsAll() {
+        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 50.0), coordinator.getUserId());
+        service.create(new GradingCriteriaCreateRequestDto("STATEMENT_OF_WORK", "C2", null, 50.0), coordinator.getUserId());
+
+        List<GradingCriteriaDto> all = service.list(null);
+        assertEquals(2, all.size());
+    }
+
+    @Test
+    void listWithFilter_returnsOnlyMatchingType() {
+        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 50.0), coordinator.getUserId());
+        service.create(new GradingCriteriaCreateRequestDto("STATEMENT_OF_WORK", "C2", null, 50.0), coordinator.getUserId());
+
+        List<GradingCriteriaDto> proposals = service.list("PROPOSAL");
+        assertEquals(1, proposals.size());
+        assertEquals("PROPOSAL", proposals.get(0).deliverableType());
+    }
+
+    @Test
+    void listWithBlankFilter_returnsAll() {
+        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 40.0), coordinator.getUserId());
+
+        List<GradingCriteriaDto> all = service.list("  ");
+        assertEquals(1, all.size());
+    }
+
+    @Test
+    void listWithInvalidFilter_throwsBadRequest() {
+        assertThrows(BadRequestException.class, () -> service.list("BOGUS"));
+    }
+}

--- a/backend/src/test/java/com/spms/backend/service/GradingCriteriaServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/GradingCriteriaServiceTest.java
@@ -3,60 +3,33 @@ package com.spms.backend.service;
 import com.spms.backend.dto.request.GradingCriteriaCreateRequestDto;
 import com.spms.backend.dto.response.GradingCriteriaDto;
 import com.spms.backend.exception.BadRequestException;
-import com.spms.backend.exception.ForbiddenException;
-import com.spms.backend.model.User;
 import com.spms.backend.repository.InMemoryGradingCriteriaRepository;
-import com.spms.backend.repository.InMemoryUserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class GradingCriteriaServiceTest {
 
-    private InMemoryUserRepository userRepository;
+    private static final Long CREATOR_ID = 1L;
+
     private InMemoryGradingCriteriaRepository criteriaRepository;
     private GradingCriteriaService service;
 
-    private User coordinator;
-    private User professor;
-    private User student;
-
     @BeforeEach
     void setUp() {
-        userRepository = new InMemoryUserRepository();
         criteriaRepository = new InMemoryGradingCriteriaRepository();
-        service = new GradingCriteriaService(criteriaRepository, userRepository);
-
-        coordinator = makeUser("coordinator");
-        professor = makeUser("professor");
-        student = makeUser("student");
-    }
-
-    private User makeUser(String role) {
-        User u = new User();
-        u.setFullName("Test " + role);
-        u.setEmail(role + "@test.com");
-        u.setRole(role);
-        u.setCreatedAt(Instant.now());
-        if ("student".equals(role)) {
-            u.setStudentId("1234567890" + role.length());
-        } else {
-            u.setPasswordHash("pbkdf2$65536$salt$hash");
-            u.setRequiresPasswordChange(false);
-        }
-        return userRepository.save(u);
+        service = new GradingCriteriaService(criteriaRepository);
     }
 
     // ── create ──────────────────────────────────────────────────────────
 
     @Test
-    void createAsCoordinator_succeeds() {
+    void create_succeeds() {
         var req = new GradingCriteriaCreateRequestDto("PROPOSAL", "Technical Feasibility", "Desc", 30.0);
-        GradingCriteriaDto dto = service.create(req, coordinator.getUserId());
+        GradingCriteriaDto dto = service.create(req, CREATOR_ID);
 
         assertNotNull(dto.id());
         assertEquals("PROPOSAL", dto.deliverableType());
@@ -66,29 +39,17 @@ class GradingCriteriaServiceTest {
     }
 
     @Test
-    void createAsProfessor_throwsForbidden() {
-        var req = new GradingCriteriaCreateRequestDto("PROPOSAL", "Clarity", null, 20.0);
-        assertThrows(ForbiddenException.class, () -> service.create(req, professor.getUserId()));
-    }
-
-    @Test
-    void createAsStudent_throwsForbidden() {
-        var req = new GradingCriteriaCreateRequestDto("PROPOSAL", "Clarity", null, 20.0);
-        assertThrows(ForbiddenException.class, () -> service.create(req, student.getUserId()));
-    }
-
-    @Test
     void createWithInvalidDeliverableType_throwsBadRequest() {
         var req = new GradingCriteriaCreateRequestDto("INVALID_TYPE", "Name", null, 10.0);
-        assertThrows(BadRequestException.class, () -> service.create(req, coordinator.getUserId()));
+        assertThrows(BadRequestException.class, () -> service.create(req, CREATOR_ID));
     }
 
     // ── list ─────────────────────────────────────────────────────────────
 
     @Test
     void listWithoutFilter_returnsAll() {
-        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 50.0), coordinator.getUserId());
-        service.create(new GradingCriteriaCreateRequestDto("STATEMENT_OF_WORK", "C2", null, 50.0), coordinator.getUserId());
+        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 50.0), CREATOR_ID);
+        service.create(new GradingCriteriaCreateRequestDto("STATEMENT_OF_WORK", "C2", null, 50.0), CREATOR_ID);
 
         List<GradingCriteriaDto> all = service.list(null);
         assertEquals(2, all.size());
@@ -96,8 +57,8 @@ class GradingCriteriaServiceTest {
 
     @Test
     void listWithFilter_returnsOnlyMatchingType() {
-        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 50.0), coordinator.getUserId());
-        service.create(new GradingCriteriaCreateRequestDto("STATEMENT_OF_WORK", "C2", null, 50.0), coordinator.getUserId());
+        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 50.0), CREATOR_ID);
+        service.create(new GradingCriteriaCreateRequestDto("STATEMENT_OF_WORK", "C2", null, 50.0), CREATOR_ID);
 
         List<GradingCriteriaDto> proposals = service.list("PROPOSAL");
         assertEquals(1, proposals.size());
@@ -106,7 +67,7 @@ class GradingCriteriaServiceTest {
 
     @Test
     void listWithBlankFilter_returnsAll() {
-        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 40.0), coordinator.getUserId());
+        service.create(new GradingCriteriaCreateRequestDto("PROPOSAL", "C1", null, 40.0), CREATOR_ID);
 
         List<GradingCriteriaDto> all = service.list("  ");
         assertEquals(1, all.size());


### PR DESCRIPTION
## What changed

- Added `DeliverableType` enum (`PROPOSAL`, `REVISED_PROPOSAL`, `STATEMENT_OF_WORK`) with JPA converter
- Added `GradingCriteria` JPA entity mapped to `grading_criteria` table
- Added `GradingCriteriaRepository` with `findByDeliverableType` query
- Added `GradingCriteriaService` with COORDINATOR role enforcement
- Added `GradingCriteriaController` exposing:
  - `POST /api/v1/grading-criteria` — Coordinator only (201 / 403)
  - `GET /api/v1/grading-criteria?deliverableType=PROPOSAL` — filtered list (200)

## How to test

**Unit tests (no DB):**
```bash
mvn test -Dtest="GradingCriteriaServiceTest"
```
**API tests (DB required):**
```bash
mvn test -Dtest="GradingCriteriaApiTest"
```
**Expected behavior:**
- POST with non-coordinator role → 403
- POST with invalid deliverableType → 400
- GET without filter → all criteria
- GET with ?deliverableType=PROPOSAL → only PROPOSAL criteria
