### PR TITLE
feat: implement global notification dropdown UI (Resolves #92)

### DIFF
--- a/frontend/app/groups/[groupId]/integrations/github/page.tsx
+++ b/frontend/app/groups/[groupId]/integrations/github/page.tsx
@@ -8,7 +8,6 @@ import GithubStatusCard from "@/components/GithubStatusCard";
 import IntegrationTestCard from "@/components/IntegrationTestCard";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import AppTopbar from "@/components/AppTopbar";
-import { useNotifications } from "@/components/NotificationProvider";
 import { fetchGroupDetail } from "@/lib/groups-api";
 import { fetchGithubIntegration, type GithubIntegrationApiResponse } from "@/lib/integrations-api";
 import { getUser } from "@/lib/auth";
@@ -17,7 +16,6 @@ export default function GithubIntegrationPage() {
     const params = useParams();
     const groupId = Number(params.groupId);
 
-    const { unreadOrPendingCount } = useNotifications();
     const currentUser = getUser();
 
     const [group, setGroup] = useState<any>(null);
@@ -101,10 +99,7 @@ export default function GithubIntegrationPage() {
         <>
             <main className="min-h-screen bg-gray-950 px-6 py-10 text-white">
                 <div className="mx-auto max-w-4xl space-y-8">
-                    <AppTopbar
-                        title="GitHub Integration"
-                        notificationCount={unreadOrPendingCount}
-                    />
+                    <AppTopbar />
 
                     <Link
                         href={`/groups/${groupId}`}

--- a/frontend/app/groups/[groupId]/integrations/jira/page.tsx
+++ b/frontend/app/groups/[groupId]/integrations/jira/page.tsx
@@ -6,14 +6,11 @@ import Link from "next/link";
 import { toast } from "sonner";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import AppTopbar from "@/components/AppTopbar";
-import { useNotifications } from "@/components/NotificationProvider";
 import apiClient from "@/lib/client";
 
 export default function JiraIntegrationPage() {
     const params = useParams();
     const groupId = Number(params.groupId);
-
-    const { unreadOrPendingCount } = useNotifications();
 
     const [integration, setIntegration] = useState<{ spaceUrl: string; status: string } | null>(null);
     const [loading, setLoading] = useState(true);
@@ -91,10 +88,7 @@ export default function JiraIntegrationPage() {
         <>
             <main className="min-h-screen bg-gray-950 px-6 py-10 text-white">
                 <div className="mx-auto max-w-4xl space-y-8">
-                    <AppTopbar
-                        title="JIRA Integration"
-                        notificationCount={unreadOrPendingCount}
-                    />
+                    <AppTopbar />
 
                     <Link
                         href={`/groups/${groupId}`}

--- a/frontend/app/groups/page.tsx
+++ b/frontend/app/groups/page.tsx
@@ -5,7 +5,6 @@ import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import GroupCard from "@/components/GroupCard";
 import GroupCardSkeleton from "@/components/GroupCardSkeleton";
 import AppTopbar from "@/components/AppTopbar";
-import { useNotifications } from "@/components/NotificationProvider";
 import { fetchGroups, createGroupApi, ApiGroupListItem } from "@/lib/groups-api";
 import { Group } from "@/lib/group-types";
 import { getUser } from "@/lib/auth";
@@ -53,7 +52,6 @@ export default function GroupsPage() {
     const [showCreateForm, setShowCreateForm] = useState(false);
 
     const pageSize = 6;
-    const { unreadOrPendingCount } = useNotifications();
     const currentUser = getUser();
 
     useEffect(() => {
@@ -157,7 +155,7 @@ export default function GroupsPage() {
     return (
         <main className="min-h-screen bg-gray-950 px-6 py-10">
             <div className="mx-auto max-w-6xl">
-                <AppTopbar title="Groups" notificationCount={unreadOrPendingCount} />
+                <AppTopbar />
 
                 <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                     <div>

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -10,7 +10,6 @@ export default function NotificationsPage() {
     const router = useRouter();
     const {
         notifications,
-        unreadOrPendingCount,
         respondToNotification,
         clearNotification,
     } = useNotifications();
@@ -44,11 +43,7 @@ export default function NotificationsPage() {
     return (
         <main className="min-h-screen bg-gray-950 px-6 py-10 text-white">
             <div className="mx-auto max-w-5xl space-y-8">
-                <AppTopbar
-                    title="Notifications"
-                    notificationCount={unreadOrPendingCount}
-                    hideNotification
-                />
+                <AppTopbar hideNotification />
 
                 <div>
                     <button

--- a/frontend/components/AppTopbar.tsx
+++ b/frontend/components/AppTopbar.tsx
@@ -1,26 +1,17 @@
 "use client";
 
-import Link from "next/link";
-import NotificationBell from "@/components/NotificationBell";
+import NotificationDropdown from "@/components/NotificationDropdown";
 
 type Props = {
-    title?: string;
-    notificationCount?: number;
     hideNotification?: boolean;
 };
 
 export default function AppTopbar({
-    title = "SPMS",
-    notificationCount = 0,
     hideNotification = false,
 }: Props) {
     return (
         <header className="mb-8 flex items-center justify-end">
-            {!hideNotification && (
-                <Link href="/notifications" aria-label="Open notifications">
-                    <NotificationBell count={notificationCount} />
-                </Link>
-            )}
+            {!hideNotification && <NotificationDropdown />}
         </header>
     );
 }

--- a/frontend/components/NotificationDropdown.tsx
+++ b/frontend/components/NotificationDropdown.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useNotifications } from "@/components/NotificationProvider";
+import { markNotificationRead } from "@/lib/notifications-api";
+import { Notification, NotificationType } from "@/lib/notification-types";
+
+function getIcon(type: NotificationType): string {
+    switch (type) {
+        case "membership_invite": return "📩";
+        case "advisor_request":
+        case "advisor_decision": return "👨‍🏫";
+        case "group_disbanded": return "🚫";
+        case "system_alert": return "⚠️";
+        default: return "🔔";
+    }
+}
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString("en-US", {
+        day: "numeric",
+        month: "short",
+        hour: "2-digit",
+        minute: "2-digit",
+    });
+}
+
+export default function NotificationDropdown() {
+    const router = useRouter();
+    const { notifications, unreadOrPendingCount, loading, refresh } = useNotifications();
+    const [open, setOpen] = useState(false);
+    const panelRef = useRef<HTMLDivElement>(null);
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    // Close on outside click
+    useEffect(() => {
+        function handleClick(e: MouseEvent) {
+            if (
+                panelRef.current && !panelRef.current.contains(e.target as Node) &&
+                buttonRef.current && !buttonRef.current.contains(e.target as Node)
+            ) {
+                setOpen(false);
+            }
+        }
+        if (open) document.addEventListener("mousedown", handleClick);
+        return () => document.removeEventListener("mousedown", handleClick);
+    }, [open]);
+
+    // Refresh when dropdown opens
+    useEffect(() => {
+        if (open) refresh();
+    }, [open, refresh]);
+
+    async function handleNotificationClick(n: Notification) {
+        if (n.status === "pending") {
+            try {
+                await markNotificationRead(n.id);
+                refresh();
+            } catch {
+                // best-effort
+            }
+        }
+        if (n.groupId) {
+            setOpen(false);
+            router.push(`/groups/${n.groupId}`);
+        }
+    }
+
+    const preview = notifications.slice(0, 10);
+
+    return (
+        <div className="relative">
+            {/* Bell button */}
+            <button
+                ref={buttonRef}
+                onClick={() => setOpen((v) => !v)}
+                aria-label="Open notifications"
+                className="relative inline-flex items-center justify-center rounded-xl border border-white/10 bg-gray-900/70 p-3 shadow-lg shadow-black/20 backdrop-blur transition-colors hover:bg-white/5 active:scale-95"
+            >
+                <span className="text-lg">🔔</span>
+                {unreadOrPendingCount > 0 && (
+                    <span className="absolute -right-1 -top-1 inline-flex min-w-[20px] items-center justify-center rounded-full bg-red-500 px-1.5 py-0.5 text-xs font-semibold text-white">
+                        {unreadOrPendingCount > 99 ? "99+" : unreadOrPendingCount}
+                    </span>
+                )}
+            </button>
+
+            {/* Dropdown panel */}
+            {open && (
+                <div
+                    ref={panelRef}
+                    className="absolute right-0 top-full z-50 mt-2 w-80 rounded-2xl border border-white/8 bg-gray-900 shadow-2xl shadow-black/40"
+                >
+                    {/* Header */}
+                    <div className="flex items-center justify-between border-b border-white/8 px-4 py-3">
+                        <span className="text-sm font-semibold text-white">Notifications</span>
+                        {unreadOrPendingCount > 0 && (
+                            <span className="text-xs text-gray-500">{unreadOrPendingCount} unread</span>
+                        )}
+                    </div>
+
+                    {/* Body */}
+                    <div className="max-h-96 overflow-y-auto">
+                        {loading ? (
+                            <div className="flex items-center justify-center py-10">
+                                <svg className="w-5 h-5 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
+                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                </svg>
+                            </div>
+                        ) : preview.length === 0 ? (
+                            <div className="py-10 text-center">
+                                <p className="text-sm text-gray-400">No notifications</p>
+                            </div>
+                        ) : (
+                            <ul>
+                                {preview.map((n) => (
+                                    <li key={n.id}>
+                                        <button
+                                            onClick={() => handleNotificationClick(n)}
+                                            className={`w-full px-4 py-3 text-left transition-colors hover:bg-white/5 ${
+                                                n.status === "pending" ? "bg-white/[0.03]" : ""
+                                            }`}
+                                        >
+                                            <div className="flex items-start gap-3">
+                                                <span className="mt-0.5 text-base">{getIcon(n.type)}</span>
+                                                <div className="min-w-0 flex-1">
+                                                    <div className="flex items-center gap-2">
+                                                        <p className="truncate text-sm text-white">
+                                                            {n.message}
+                                                        </p>
+                                                        {n.status === "pending" && (
+                                                            <span className="h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" />
+                                                        )}
+                                                    </div>
+                                                    <p className="mt-1 text-xs text-gray-600">
+                                                        {formatDate(n.createdAt)}
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </button>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </div>
+
+                    {/* Footer */}
+                    <div className="border-t border-white/8 px-4 py-2">
+                        <button
+                            onClick={() => { setOpen(false); router.push("/notifications"); }}
+                            className="w-full py-1 text-center text-xs text-blue-400 transition-colors hover:text-blue-300"
+                        >
+                            View all notifications →
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/frontend/lib/notifications-api.ts
+++ b/frontend/lib/notifications-api.ts
@@ -106,6 +106,23 @@ export async function clearNotificationApi(notificationId: number): Promise<void
 }
 
 /**
+ * Mark a single notification as read (issue #92).
+ */
+export async function markNotificationRead(notificationId: number): Promise<void> {
+    const res = await fetch(
+        `${API_BASE}/notifications/${notificationId}/read`,
+        {
+            method: "PATCH",
+            headers: authHeaders(),
+        }
+    );
+
+    if (!res.ok && res.status !== 204) {
+        throw new Error(await parseError(res));
+    }
+}
+
+/**
  * P2-API-05: Leader invites a student to the group (ns_f1).
  */
 export async function inviteMemberApi(


### PR DESCRIPTION
## What does this PR do?

Implements the global notification bell icon and dropdown component that dynamically displays notifications for all user roles (student, professor, coordinator).

## Changes

- **`NotificationDropdown.tsx`** — New component: bell icon with unread badge, popover panel with notification list, loading state, and "View all" footer link
- **`AppTopbar.tsx`** — Replaced static link+bell with the new `NotificationDropdown` component; removed unused `title` and `notificationCount` props
- **`notifications-api.ts`** — Added `markNotificationRead` function (`PATCH /notifications/{id}/read`)
- **`groups/page.tsx`, `github/page.tsx`, `jira/page.tsx`, `notifications/page.tsx`** — Cleaned up removed props from `AppTopbar` callers

## How it works

- Unread badge count is driven by `useNotifications()` hook (already connected to `GET /notifications` in `NotificationProvider`)
- Clicking a notification triggers `PATCH /notifications/{id}/read` and visually marks it as read via `refresh()`
- Dropdown refreshes its list every time it is opened

## How to test

1. Log in as any user role
2. Confirm the bell icon appears in the top-right corner
3. If there are pending notifications, the red badge should show the count
4. Open the dropdown — notifications should load from the API
5. Click a notification — it should be marked as read and the blue dot should disappear
6. Click "View all notifications →" — should navigate to `/notifications`
