### PR TITLE
fix: resolve compile errors and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,52 @@
-# SPMS Local Setup
+# SPMS — Senior Project Management System
 
-This repository contains the frontend and backend for the Senior Project Management System (SPMS).
+## Tech Stack
+
+| Layer | Technology | Version |
+|-------|-----------|---------|
+| **Backend** | Java | 17 |
+| | Spring Boot | 3.3.4 |
+| | Spring Data JPA | (via Boot) |
+| | Spring Validation | (via Boot) |
+| | Spring AOP | (via Boot) |
+| | PostgreSQL Driver | (via Boot) |
+| | Springdoc OpenAPI | 2.6.0 |
+| | Lombok | (via Boot) |
+| | REST Assured (test) | 5.4.0 |
+| | JUnit Jupiter (test) | (via Boot) |
+| | Maven | 3.x |
+| **Frontend** | Next.js | 16.2.2 |
+| | React | 19.2.4 |
+| | TypeScript | 5.x |
+| | Tailwind CSS | 4.x |
+| | Axios | 1.x |
+| | next-auth | 4.x |
+| | Sonner (toasts) | 2.x |
+| | Lucide React (icons) | 1.x |
+| **Database** | PostgreSQL via Supabase | — |
+| **Auth** | JWT (HS256) + GitHub OAuth | — |
 
 ## Project Structure
 
-- `frontend/`: Next.js application running on `http://localhost:3000`
-- `backend/`: Spring Boot API running on `http://localhost:8080`
-- `docs/`: project documents
+- `frontend/` — Next.js application running on `http://localhost:3000`
+- `backend/` — Spring Boot API running on `http://localhost:8080`
+- `docs/` — project documents, OpenAPI specs, DFDs
 
 ## Prerequisites
 
-- Node.js and npm
-- Java 17 or newer
-- Maven
+- Node.js 18+ and npm
+- Java 17+
+- Maven 3.x
 
 ## Frontend Setup
 
-Create `frontend/.env.local` with this value:
+Create `frontend/.env.local`:
 
 ```bash
 NEXT_PUBLIC_API_URL=http://localhost:8080/api/v1
 ```
 
-Then start the frontend:
+Start the frontend:
 
 ```bash
 cd frontend
@@ -32,16 +56,16 @@ npm run dev
 
 ## Backend Setup
 
-The backend connects directly to Supabase PostgreSQL via JDBC. There is no Supabase REST API or service key involved.
+The backend connects directly to Supabase PostgreSQL via JDBC.
 
-Copy the example file:
+Copy the example config:
 
 ```bash
 cd backend
 cp application.properties.example application.properties
 ```
 
-Then open `backend/application.properties` and fill all values:
+Fill all values in `backend/application.properties`:
 
 ```properties
 github.client-id=your-shared-team-client-id
@@ -56,12 +80,7 @@ You can find the connection string in:
 
 Copy the URI value and prefix it with `jdbc:` before pasting into `db.url`.
 
-Important notes:
-
-- `backend/application.properties` is local-only and gitignored.
-- Spring Boot auto-loads `application.properties` when you run the backend from the `backend/` directory.
-- Share real credentials privately with teammates. Do not commit them to GitHub.
-- The GitHub OAuth App must use `http://localhost:3000/auth/callback` as its callback URL.
+> `backend/application.properties` is local-only and gitignored. Share real credentials privately with teammates — never commit them.
 
 Start the backend:
 
@@ -70,60 +89,17 @@ cd backend
 mvn spring-boot:run
 ```
 
+## Running the Full Project
+
+1. Create `frontend/.env.local` with the API URL.
+2. Copy `backend/application.properties.example` → `backend/application.properties` and fill all values.
+3. Start the backend: `cd backend && mvn spring-boot:run`
+4. Start the frontend: `cd frontend && npm run dev`
+5. Open `http://localhost:3000/auth/login`.
+
 ## API Documentation (Swagger)
 
-Once the backend is running, you can access:
+Once the backend is running:
 
 - **Swagger UI** → http://localhost:8080/swagger-ui.html
 - **OpenAPI JSON** → http://localhost:8080/v3/api-docs
-
-## Running The Full Project
-
-1. Create `frontend/.env.local` with the API URL.
-2. Copy `backend/application.properties.example` to `backend/application.properties`.
-3. Fill all five values in `backend/application.properties` (3 GitHub + 2 database).
-4. Start the backend with `mvn spring-boot:run` inside `backend/`.
-5. Start the frontend with `npm run dev` inside `frontend/`.
-6. Open `http://localhost:3000/auth/login`.
-
-## Student OAuth Test Flow
-
-Use the valid student ID `11111111111` for the current test flow.
-
-Expected behavior:
-
-1. Enter `11111111111` on `/auth/login`.
-2. Click `Continue with GitHub`.
-3. Confirm the redirect URL contains:
-   - a real `client_id`
-   - `redirect_uri=http://localhost:3000/auth/callback`
-   - `state=11111111111`
-4. Complete GitHub authorization.
-5. Return to `/auth/callback` and then reach `/dashboard`.
-
-## Troubleshooting
-
-### `placeholder-client-id` appears in the GitHub URL
-
-The local `backend/application.properties` file is missing, not filled, or still contains placeholder values.
-
-### `http://localhost:8080/api/v1/auth/github/callback` appears in the GitHub URL
-
-An old backend process is still running or the backend was started with old configuration.
-
-### Student login returns `500`
-
-Most likely causes:
-
-- `db.url`, `db.username`, or `db.password` is missing or incorrect in `backend/application.properties`
-- The database tables (`users`, `valid_student_ids`) do not exist in the Supabase project
-
-### Backend does not start on `8080`
-
-Another process may already be using the port. Stop the old backend process and try again.
-
-## Security Note
-
-Before pushing this repository, make sure no real credentials remain inside tracked files.
-
-`backend/application.properties` is intended to stay local and gitignored. If a real secret was ever written into a tracked file, rotate it and replace the committed value with a placeholder.

--- a/backend/src/main/java/com/spms/backend/service/impl/ReviewServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/ReviewServiceImpl.java
@@ -43,7 +43,7 @@ public class ReviewServiceImpl implements ReviewService {
                 .orElseThrow(() -> new ForbiddenException("You are not part of any group. Access denied."));
 
         // Verify if the submission belongs to the student's group
-        if (!submission.getGroup().getId().equals(member.getGroup().getId())) {
+        if (!submission.getGroupId().equals(member.getGroup().getId())) {
             throw new ForbiddenException("You are not authorized to view reviews for this submission as it belongs to another group.");
         }
 

--- a/backend/src/test/java/com/spms/backend/service/NotificationServiceIssue81Test.java
+++ b/backend/src/test/java/com/spms/backend/service/NotificationServiceIssue81Test.java
@@ -7,7 +7,9 @@ import com.spms.backend.model.User;
 import com.spms.backend.model.notification.Notification;
 import com.spms.backend.model.notification.NotificationStatus;
 import com.spms.backend.model.notification.NotificationType;
+import com.spms.backend.repository.GroupRepository;
 import com.spms.backend.repository.NotificationRepository;
+import com.spms.backend.repository.ScheduleRepository;
 import com.spms.backend.repository.UserRepository;
 import com.spms.backend.service.impl.NotificationServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,13 +34,17 @@ class NotificationServiceIssue81Test {
     @Mock
     private UserRepository userRepository;
     @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
     private MemberService memberService;
 
     private NotificationServiceImpl notificationService;
 
     @BeforeEach
     void setUp() {
-        notificationService = new NotificationServiceImpl(notificationRepository, userRepository, memberService);
+        notificationService = new NotificationServiceImpl(notificationRepository, userRepository, groupRepository, scheduleRepository, memberService);
     }
 
     @Test

--- a/backend/src/test/java/com/spms/backend/service/NotificationServiceIssue91Test.java
+++ b/backend/src/test/java/com/spms/backend/service/NotificationServiceIssue91Test.java
@@ -8,7 +8,9 @@ import com.spms.backend.model.User;
 import com.spms.backend.model.notification.Notification;
 import com.spms.backend.model.notification.NotificationStatus;
 import com.spms.backend.model.notification.NotificationType;
+import com.spms.backend.repository.GroupRepository;
 import com.spms.backend.repository.NotificationRepository;
+import com.spms.backend.repository.ScheduleRepository;
 import com.spms.backend.repository.UserRepository;
 import com.spms.backend.service.impl.NotificationServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +40,10 @@ class NotificationServiceIssue91Test {
     @Mock
     private UserRepository userRepository;
     @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private ScheduleRepository scheduleRepository;
+    @Mock
     private MemberService memberService;
 
     private NotificationServiceImpl notificationService;
@@ -45,7 +51,7 @@ class NotificationServiceIssue91Test {
 
     @BeforeEach
     void setUp() {
-        notificationService = new NotificationServiceImpl(notificationRepository, userRepository, memberService);
+        notificationService = new NotificationServiceImpl(notificationRepository, userRepository, groupRepository, scheduleRepository, memberService);
         pageable = PageRequest.of(0, 10);
     }
 


### PR DESCRIPTION
## Summary

- `ReviewServiceImpl`: `submission.getGroup().getId()` → `submission.getGroupId()` — `Submission` entity exposes `groupId` as a Long, not a JPA relation; call was causing a compile error.
- `NotificationServiceIssue81/91Test`: added missing `GroupRepository` and `ScheduleRepository` mocks to match the updated `NotificationServiceImpl` constructor signature — tests were failing to compile.
- `README.md`: added tech stack table with versions at the top; removed stale Student OAuth Test Flow, Troubleshooting, and Security Note sections.

## How to test

```bash
cd backend && mvn test-compile   # must be clean
cd backend && mvn compile        # must be clean
```