### PR TITLE
Process 3 - Revision Submission UI Flow #156

### DIFF
--- a/frontend/app/groups/[groupId]/submissions/new/page.tsx
+++ b/frontend/app/groups/[groupId]/submissions/new/page.tsx
@@ -1,19 +1,26 @@
 "use client";
 
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import StudentSubmissionForm from "@/components/StudentSubmissionForm";
 import { getToken, getUser } from "@/lib/auth";
 import { mockGroups } from "@/lib/mock-groups";
+import { fetchSubmissionReviews, type SubmissionReview } from "@/lib/submissions-api";
 
 type AuthState = "loading" | "ready" | "unauthorized";
 
 export default function NewSubmissionPage() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const [authState, setAuthState] = useState<AuthState>("loading");
   const [studentId, setStudentId] = useState<string | null>(null);
+  const [reviewerComments, setReviewerComments] = useState<SubmissionReview[]>([]);
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [commentsError, setCommentsError] = useState<string | undefined>();
+  const parentSubmissionId = searchParams.get("parentSubmissionId")?.trim() || undefined;
+  const isRevisionFlow = Boolean(parentSubmissionId);
 
   useEffect(() => {
     const token = getToken();
@@ -37,6 +44,45 @@ export default function NewSubmissionPage() {
     setStudentId(user.studentId ?? null);
     setAuthState("ready");
   }, [router]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadReviewerComments() {
+      if (!parentSubmissionId) {
+        setReviewerComments([]);
+        setCommentsError(undefined);
+        return;
+      }
+
+      setCommentsLoading(true);
+      setCommentsError(undefined);
+
+      try {
+        const response = await fetchSubmissionReviews(parentSubmissionId);
+        if (!cancelled) {
+          setReviewerComments(response.data ?? []);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          // TODO(#156): replace this fallback once the backend review-history
+          // endpoint is available in all environments.
+          setReviewerComments([]);
+          setCommentsError(error instanceof Error ? error.message : "Reviewer comments could not be loaded.");
+        }
+      } finally {
+        if (!cancelled) {
+          setCommentsLoading(false);
+        }
+      }
+    }
+
+    loadReviewerComments();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [parentSubmissionId]);
 
   const rawGroupId = params.groupId;
   const groupId = Array.isArray(rawGroupId) ? rawGroupId[0] : rawGroupId;
@@ -91,9 +137,13 @@ export default function NewSubmissionPage() {
             <Link href={`/groups/${group.groupId}`} className="text-sm text-blue-300 transition-colors hover:text-blue-200">
               {"<- Back to group"}
             </Link>
-            <h1 className="mt-6 text-3xl font-bold">Student Submission Form</h1>
+            <h1 className="mt-6 text-3xl font-bold">
+              {isRevisionFlow ? "Student Revision Form" : "Student Submission Form"}
+            </h1>
             <p className="mt-2 text-gray-400">
-              Select the deliverable type, attach your file, and submit it for your group.
+              {isRevisionFlow
+                ? "Review the committee comments, attach the revised file, and submit it for your group."
+                : "Select the deliverable type, attach your file, and submit it for your group."}
             </p>
           </div>
 
@@ -113,6 +163,11 @@ export default function NewSubmissionPage() {
           groupName={group.groupName}
           disabled={disabled}
           disabledReason={disabled ? disabledReason : undefined}
+          mode={isRevisionFlow ? "revision" : "new"}
+          parentSubmissionId={parentSubmissionId}
+          reviewerComments={reviewerComments}
+          commentsLoading={commentsLoading}
+          commentsError={commentsError}
         />
       </div>
     </main>

--- a/frontend/app/groups/[groupId]/submissions/new/page.tsx
+++ b/frontend/app/groups/[groupId]/submissions/new/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import StudentSubmissionForm from "@/components/StudentSubmissionForm";
 import { getToken, getUser } from "@/lib/auth";
 import { mockGroups } from "@/lib/mock-groups";
@@ -11,6 +11,14 @@ import { fetchSubmissionReviews, type SubmissionReview } from "@/lib/submissions
 type AuthState = "loading" | "ready" | "unauthorized";
 
 export default function NewSubmissionPage() {
+  return (
+    <Suspense fallback={<SubmissionPageSpinner />}>
+      <NewSubmissionPageContent />
+    </Suspense>
+  );
+}
+
+function NewSubmissionPageContent() {
   const router = useRouter();
   const params = useParams();
   const searchParams = useSearchParams();
@@ -171,5 +179,16 @@ export default function NewSubmissionPage() {
         />
       </div>
     </main>
+  );
+}
+
+function SubmissionPageSpinner() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-950">
+      <svg className="h-6 w-6 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+    </div>
   );
 }

--- a/frontend/components/StudentSubmissionForm.tsx
+++ b/frontend/components/StudentSubmissionForm.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 import { getToken } from "@/lib/auth";
+import { createRevisionSubmission, type SubmissionReview } from "@/lib/submissions-api";
 
 type DeliverableType = "PROPOSAL" | "STATEMENT_OF_WORK";
 type UploadStatus = "idle" | "dragging" | "uploading" | "success" | "error";
@@ -36,6 +37,11 @@ interface StudentSubmissionFormProps {
   groupName: string;
   disabled?: boolean;
   disabledReason?: string;
+  mode?: "new" | "revision";
+  parentSubmissionId?: string;
+  reviewerComments?: SubmissionReview[];
+  commentsLoading?: boolean;
+  commentsError?: string;
 }
 
 export default function StudentSubmissionForm({
@@ -43,12 +49,19 @@ export default function StudentSubmissionForm({
   groupName,
   disabled = false,
   disabledReason,
+  mode = "new",
+  parentSubmissionId,
+  reviewerComments = [],
+  commentsLoading = false,
+  commentsError,
 }: StudentSubmissionFormProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [status, setStatus] = useState<UploadStatus>("idle");
   const [deliverableType, setDeliverableType] = useState<DeliverableType | "">("");
+  const [revisionDescription, setRevisionDescription] = useState("");
   const [file, setFile] = useState<File | null>(null);
   const [lastSubmission, setLastSubmission] = useState<SubmissionResponse["data"] | null>(null);
+  const isRevisionMode = mode === "revision";
 
   const validateAndSetFile = (selectedFile: File) => {
     const lowerName = selectedFile.name.toLowerCase();
@@ -102,6 +115,7 @@ export default function StudentSubmissionForm({
   const handleReset = () => {
     setFile(null);
     setDeliverableType("");
+    setRevisionDescription("");
     setStatus("idle");
     setLastSubmission(null);
 
@@ -116,7 +130,12 @@ export default function StudentSubmissionForm({
       return;
     }
 
-    if (!deliverableType) {
+    if (isRevisionMode && !parentSubmissionId) {
+      toast.error("Revision context is missing. Open the form from a revision request.");
+      return;
+    }
+
+    if (!isRevisionMode && !deliverableType) {
       toast.error("Select a deliverable type before submitting.");
       return;
     }
@@ -126,7 +145,7 @@ export default function StudentSubmissionForm({
       return;
     }
 
-    if (!process.env.NEXT_PUBLIC_API_URL) {
+    if (!isRevisionMode && !process.env.NEXT_PUBLIC_API_URL) {
       toast.error("NEXT_PUBLIC_API_URL is not configured.");
       return;
     }
@@ -137,15 +156,34 @@ export default function StudentSubmissionForm({
       return;
     }
 
-    const formData = new FormData();
-    formData.append("teamId", groupId);
-    formData.append("deliverableType", deliverableType);
-    formData.append("file", file);
-
     setStatus("uploading");
     setLastSubmission(null);
 
     try {
+      if (isRevisionMode) {
+        const payload = await createRevisionSubmission(parentSubmissionId!, {
+          file,
+          description: revisionDescription,
+        });
+
+        setStatus("success");
+        setLastSubmission(payload?.data ?? null);
+        toast.success(payload?.message || "Revision submitted successfully.");
+
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+
+        setFile(null);
+        setRevisionDescription("");
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append("teamId", groupId);
+      formData.append("deliverableType", deliverableType);
+      formData.append("file", file);
+
       const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/submissions`, {
         method: "POST",
         headers: {
@@ -191,8 +229,12 @@ export default function StudentSubmissionForm({
             </svg>
           </div>
           <div>
-            <p className="text-sm font-semibold text-white">Deliverable Submission</p>
-            <p className="text-xs text-gray-500">Select a deliverable type and upload your file</p>
+            <p className="text-sm font-semibold text-white">
+              {isRevisionMode ? "Revision Submission" : "Deliverable Submission"}
+            </p>
+            <p className="text-xs text-gray-500">
+              {isRevisionMode ? "Review comments first, then upload the revised document" : "Select a deliverable type and upload your file"}
+            </p>
           </div>
         </div>
 
@@ -203,6 +245,16 @@ export default function StudentSubmissionForm({
               <p className="mt-1 text-sm font-medium text-white">{groupName}</p>
             </div>
 
+            {isRevisionMode && (
+              <ReviewerCommentsPanel
+                parentSubmissionId={parentSubmissionId}
+                comments={reviewerComments}
+                loading={commentsLoading}
+                error={commentsError}
+              />
+            )}
+
+            {!isRevisionMode && (
             <div className="space-y-2">
               <label htmlFor="deliverableType" className="text-sm font-medium text-gray-300">
                 Deliverable type
@@ -231,6 +283,24 @@ export default function StudentSubmissionForm({
                   : "Choose the document type that matches the current milestone."}
               </p>
             </div>
+            )}
+
+            {isRevisionMode && (
+              <div className="space-y-2">
+                <label htmlFor="revisionDescription" className="text-sm font-medium text-gray-300">
+                  Revision notes
+                </label>
+                <textarea
+                  id="revisionDescription"
+                  value={revisionDescription}
+                  onChange={(event) => setRevisionDescription(event.target.value)}
+                  rows={4}
+                  disabled={disabled || status === "uploading"}
+                  placeholder="Summarize the changes made in this revised document..."
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder-gray-600 outline-none transition focus:border-blue-500/50 focus:ring-2 focus:ring-blue-500/30 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+              </div>
+            )}
 
             <div className="space-y-2">
               <div className="flex items-center justify-between">
@@ -344,12 +414,12 @@ export default function StudentSubmissionForm({
                         d="M12 16.5V7.5m0 0-3 3m3-3 3 3M21 16.5v1.125A2.625 2.625 0 0118.375 20.25H5.625A2.625 2.625 0 013 17.625V16.5"
                       />
                     </svg>
-                    Submit deliverable
+                    {isRevisionMode ? "Submit revision" : "Submit deliverable"}
                   </>
                 )}
               </button>
 
-              {(file || deliverableType) && status !== "uploading" && (
+              {(file || deliverableType || revisionDescription) && status !== "uploading" && (
                 <button
                   type="button"
                   onClick={handleReset}
@@ -365,22 +435,38 @@ export default function StudentSubmissionForm({
             <div className="bg-gray-950/40 border border-white/8 rounded-2xl overflow-hidden">
               <div className="px-5 py-4 border-b border-white/5">
                 <p className="text-sm font-semibold text-white">Submission Rules</p>
-                <p className="text-xs text-gray-500 mt-1">This page only covers the student-side upload flow.</p>
+                <p className="text-xs text-gray-500 mt-1">
+                  {isRevisionMode ? "This flow links the new upload to the requested revision." : "This page only covers the student-side upload flow."}
+                </p>
               </div>
               <div className="p-5 space-y-4 text-sm text-gray-300">
                 <div className="rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                   <p className="text-xs text-gray-500">Deliverable types</p>
-                  <p className="mt-1 text-white">Proposal, Statement of Work</p>
+                  <p className="mt-1 text-white">
+                    {isRevisionMode ? "Revision of requested deliverable" : "Proposal, Statement of Work"}
+                  </p>
                 </div>
 
                 <div className="rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                   <p className="text-xs text-gray-500">Submission target</p>
-                  <p className="mt-1 font-mono text-blue-200">POST /submissions</p>
+                  <p className="mt-1 font-mono text-blue-200">
+                    {isRevisionMode ? "POST /submissions/{parentSubmissionId}/revisions" : "POST /submissions"}
+                  </p>
                 </div>
 
                 <div className="rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                   <p className="text-xs text-gray-500">Request payload</p>
-                  <p className="mt-1">Multipart form with <span className="font-mono text-white">teamId</span>, <span className="font-mono text-white">deliverableType</span>, and file.</p>
+                  <p className="mt-1">
+                    {isRevisionMode ? (
+                      <>
+                        Multipart form with file and optional <span className="font-mono text-white">description</span>, linked to parent <span className="font-mono text-white">{parentSubmissionId ?? "unknown"}</span>.
+                      </>
+                    ) : (
+                      <>
+                        Multipart form with <span className="font-mono text-white">teamId</span>, <span className="font-mono text-white">deliverableType</span>, and file.
+                      </>
+                    )}
+                  </p>
                 </div>
               </div>
             </div>
@@ -392,8 +478,8 @@ export default function StudentSubmissionForm({
 
               <div className="p-5 space-y-3 text-sm text-gray-300">
                 <div className="flex items-start gap-3">
-                  <span className={`mt-1 h-2.5 w-2.5 rounded-full ${deliverableType ? "bg-green-400" : "bg-gray-600"}`} />
-                  <span>Deliverable type is selected.</span>
+                  <span className={`mt-1 h-2.5 w-2.5 rounded-full ${isRevisionMode ? (parentSubmissionId ? "bg-green-400" : "bg-gray-600") : (deliverableType ? "bg-green-400" : "bg-gray-600")}`} />
+                  <span>{isRevisionMode ? "Parent submission is linked." : "Deliverable type is selected."}</span>
                 </div>
                 <div className="flex items-start gap-3">
                   <span className={`mt-1 h-2.5 w-2.5 rounded-full ${file ? "bg-green-400" : "bg-gray-600"}`} />
@@ -424,4 +510,75 @@ export default function StudentSubmissionForm({
       </div>
     </div>
   );
+}
+
+function ReviewerCommentsPanel({
+  parentSubmissionId,
+  comments,
+  loading,
+  error,
+}: {
+  parentSubmissionId?: string;
+  comments: SubmissionReview[];
+  loading: boolean;
+  error?: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-orange-500/20 bg-orange-500/8 overflow-hidden">
+      <div className="border-b border-orange-500/10 px-5 py-4">
+        <p className="text-sm font-semibold text-white">Reviewer Comments</p>
+        <p className="mt-1 text-xs text-orange-100/70">
+          Parent submission: <span className="font-mono text-orange-50">{parentSubmissionId ?? "not linked"}</span>
+        </p>
+      </div>
+
+      <div className="space-y-3 p-5">
+        {loading && (
+          <div className="flex items-center gap-3 rounded-xl border border-white/8 bg-white/4 px-4 py-3 text-sm text-gray-300">
+            <svg className="h-4 w-4 animate-spin text-orange-300" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 0 1 8-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            Loading reviewer comments...
+          </div>
+        )}
+
+        {!loading && error && (
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+            {error}
+          </div>
+        )}
+
+        {!loading && !error && comments.length === 0 && (
+          <div className="rounded-xl border border-white/8 bg-white/4 px-4 py-3 text-sm text-gray-300">
+            No reviewer comments are available yet.
+          </div>
+        )}
+
+        {!loading && comments.map((comment) => (
+          <article key={comment.id} className="rounded-xl border border-white/8 bg-gray-950/40 px-4 py-3">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-sm font-medium text-white">{comment.reviewerName || "Committee reviewer"}</p>
+              <span className="rounded-full border border-orange-400/20 bg-orange-400/10 px-2.5 py-1 text-xs font-medium text-orange-200">
+                {comment.status === "REVISION_REQUESTED" ? "Revision requested" : "Approved"}
+              </span>
+            </div>
+            <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-gray-300">{comment.comments}</p>
+            <p className="mt-3 text-xs text-gray-500">{formatCommentDate(comment.reviewedAt)}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatCommentDate(value: string) {
+  if (!value) return "Date unavailable";
+  return new Date(value).toLocaleString("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }

--- a/frontend/lib/submissions-api.ts
+++ b/frontend/lib/submissions-api.ts
@@ -19,6 +19,32 @@ export interface SubmissionSummary {
   isOverdue: boolean;
 }
 
+export interface SubmissionReview {
+  id: string;
+  reviewerId: string;
+  reviewerName: string;
+  comments: string;
+  status: "APPROVED" | "REVISION_REQUESTED";
+  reviewedAt: string;
+}
+
+export interface ReviewListResponse {
+  status: string;
+  data: SubmissionReview[];
+}
+
+export interface RevisionCreateResponse {
+  status: string;
+  message?: string;
+  data?: {
+    id?: string;
+    parentSubmissionId?: string;
+    revisionNumber?: number;
+    status?: SubmissionStatus;
+    submittedAt?: string;
+  };
+}
+
 export interface PaginationMeta {
   page: number;
   size: number;
@@ -70,6 +96,57 @@ export async function fetchSubmissions(filters: SubmissionFilters = {}): Promise
 
   const res = await fetch(`${API_BASE}/submissions?${params.toString()}`, {
     headers: buildHeaders(),
+  });
+
+  if (!res.ok) {
+    const msg = await parseError(res);
+    throw new Error(msg);
+  }
+
+  return res.json();
+}
+
+export async function fetchSubmissionReviews(submissionId: string): Promise<ReviewListResponse> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), 4000);
+
+  try {
+    const res = await fetch(`${API_BASE}/submissions/${submissionId}/reviews`, {
+      headers: buildHeaders(),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const msg = await parseError(res);
+      throw new Error(msg);
+    }
+
+    return res.json();
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+export async function createRevisionSubmission(
+  parentSubmissionId: string,
+  payload: { file: File; description?: string },
+): Promise<RevisionCreateResponse> {
+  const token = getToken();
+  const formData = new FormData();
+  formData.append("file", payload.file);
+  if (payload.description?.trim()) {
+    formData.append("description", payload.description.trim());
+  }
+
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  // TODO(#156): keep this endpoint aligned with the backend once Process 3
+  // revision upload support is implemented end-to-end.
+  const res = await fetch(`${API_BASE}/submissions/${parentSubmissionId}/revisions`, {
+    method: "POST",
+    headers,
+    body: formData,
   });
 
   if (!res.ok) {


### PR DESCRIPTION
## Summary
Implements the frontend UI flow for students to submit a revised document after reviewers request changes.

## Implemented 
- Added revision mode support to the student submission form.
- Reads `parentSubmissionId` from the URL query string.
- Displays reviewer comments before the upload zone, so students can review feedback before attaching a revised file.
- Adds revision notes field for students to summarize what changed.
- Sends revised uploads to the revision endpoint using the parent submission context.
- Keeps the existing normal Proposal / SoW submission flow unchanged.
- Added frontend API helpers for:
  - fetching submission review comments
  - submitting a revised document

## Backend Notes / TODO
- Backend implementation was intentionally not added because this issue is frontend-only.
- TODO comments were left where backend alignment may be needed once Process 3 revision endpoints are fully available.
- Current frontend expects:
  - `GET /submissions/{parentSubmissionId}/reviews`
  - `POST /submissions/{parentSubmissionId}/revisions`

## Testing
- Verified the revision UI manually at:
  - `/groups/101/submissions/new?parentSubmissionId=1001`
- Confirmed reviewer comments panel appears before the upload zone.
- Confirmed the form uses the provided `parentSubmissionId`.
- Ran targeted lint:

```powershell
npx.cmd eslint components\StudentSubmissionForm.tsx app\groups\[groupId]\submissions\new\page.tsx lib\submissions-api.ts
