### PR TITLE
fix: align P3/P4 frontend with backend API contracts (Resolves #228)

### DIFF
--- a/frontend/app/coordinator/advisor-override/page.tsx
+++ b/frontend/app/coordinator/advisor-override/page.tsx
@@ -109,7 +109,7 @@ function OverridePanel() {
         }).finally(() => setLoading(false));
     }, []);
 
-    const selectedTeam = assignments.find((a) => a.teamId === selectedTeamId);
+    const selectedTeam = assignments.find((a) => String(a.teamId) === selectedTeamId);
     const hasExistingAdvisor = selectedTeam?.advisorId != null;
 
     const handleOverrideClick = () => {
@@ -124,8 +124,8 @@ function OverridePanel() {
         setProcessing(true);
         try {
             await overrideAdvisorAssignment({
-                teamId: selectedTeamId,
-                advisorId: selectedAdvisorId,
+                teamId: Number(selectedTeamId),
+                advisorId: Number(selectedAdvisorId),
                 reason: overrideReason.trim() || undefined,
             });
             toast.success("Advisor assignment overridden successfully.");

--- a/frontend/app/coordinator/submissions/page.tsx
+++ b/frontend/app/coordinator/submissions/page.tsx
@@ -75,7 +75,7 @@ function SubmissionsDashboard() {
     setFilters({ status: "", deliverableType: "", deadlineStatus: "", page: 0, size: 20 });
   }
 
-  const overdueCount = submissions.filter((s) => s.isOverdue).length;
+  const overdueCount = submissions.filter((s) => s.isOverdue === true).length;
   const pendingCount = submissions.filter((s) => s.status === "PENDING_REVIEW").length;
   const gradedCount = submissions.filter((s) => s.status === "GRADED").length;
 
@@ -205,7 +205,7 @@ function SubmissionsDashboard() {
               </p>
               <div className="flex items-center gap-2">
                 <button
-                  disabled={pagination.page === 0}
+                  disabled={pagination.currentPage === 0}
                   onClick={() => setFilters((p) => ({ ...p, page: (p.page ?? 1) - 1 }))}
                   className="px-3 py-1.5 rounded-lg text-xs border border-white/10 text-gray-400
                              hover:text-white hover:bg-white/5 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
@@ -213,10 +213,10 @@ function SubmissionsDashboard() {
                   Previous
                 </button>
                 <span className="text-xs text-gray-500">
-                  Page {pagination.page + 1} of {pagination.totalPages}
+                  Page {pagination.currentPage + 1} of {pagination.totalPages}
                 </span>
                 <button
-                  disabled={pagination.page >= pagination.totalPages - 1}
+                  disabled={pagination.currentPage >= pagination.totalPages - 1}
                   onClick={() => setFilters((p) => ({ ...p, page: (p.page ?? 0) + 1 }))}
                   className="px-3 py-1.5 rounded-lg text-xs border border-white/10 text-gray-400
                              hover:text-white hover:bg-white/5 disabled:opacity-40 disabled:cursor-not-allowed transition-all"
@@ -235,6 +235,7 @@ function SubmissionsDashboard() {
 // ─── Submission row ───────────────────────────────────────────────────────────
 
 function SubmissionRow({ submission: s }: { submission: SubmissionSummary }) {
+  const teamLabel = s.teamName ?? `Team #${s.teamId}`;
   return (
     <tr className={`transition-colors hover:bg-white/[0.02] ${s.isOverdue ? "bg-red-500/5" : ""}`}>
       <td className="px-5 py-4">
@@ -247,7 +248,7 @@ function SubmissionRow({ submission: s }: { submission: SubmissionSummary }) {
               </svg>
             </span>
           )}
-          <span className="font-medium text-white truncate max-w-[160px]">{s.teamName}</span>
+          <span className="font-medium text-white truncate max-w-[160px]">{teamLabel}</span>
         </div>
       </td>
       <td className="px-5 py-4">
@@ -257,7 +258,7 @@ function SubmissionRow({ submission: s }: { submission: SubmissionSummary }) {
         <SubmissionStatusBadge status={s.status} />
       </td>
       <td className="px-5 py-4 text-gray-400 text-center">
-        {s.revisionNumber}
+        {s.revisionNumber ?? "—"}
       </td>
       <td className="px-5 py-4 text-gray-400 whitespace-nowrap">
         {formatDate(s.submittedAt)}

--- a/frontend/app/groups/[groupId]/submissions/new/page.tsx
+++ b/frontend/app/groups/[groupId]/submissions/new/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import StudentSubmissionForm from "@/components/StudentSubmissionForm";
 import { getToken, getUser } from "@/lib/auth";
-import { mockGroups } from "@/lib/mock-groups";
+import { fetchGroupDetail, type ApiGroupDetail } from "@/lib/groups-api";
 import { fetchSubmissionReviews, type SubmissionReview } from "@/lib/submissions-api";
 
 type AuthState = "loading" | "ready" | "unauthorized";
@@ -24,11 +24,17 @@ function NewSubmissionPageContent() {
   const searchParams = useSearchParams();
   const [authState, setAuthState] = useState<AuthState>("loading");
   const [studentId, setStudentId] = useState<string | null>(null);
+  const [group, setGroup] = useState<ApiGroupDetail | null>(null);
+  const [groupError, setGroupError] = useState<string | null>(null);
   const [reviewerComments, setReviewerComments] = useState<SubmissionReview[]>([]);
   const [commentsLoading, setCommentsLoading] = useState(false);
   const [commentsError, setCommentsError] = useState<string | undefined>();
   const parentSubmissionId = searchParams.get("parentSubmissionId")?.trim() || undefined;
   const isRevisionFlow = Boolean(parentSubmissionId);
+
+  const rawGroupId = params.groupId;
+  const groupIdStr = Array.isArray(rawGroupId) ? rawGroupId[0] : rawGroupId;
+  const groupIdNum = groupIdStr ? Number(groupIdStr) : null;
 
   useEffect(() => {
     const token = getToken();
@@ -54,6 +60,17 @@ function NewSubmissionPageContent() {
   }, [router]);
 
   useEffect(() => {
+    if (!groupIdNum) return;
+    let cancelled = false;
+
+    fetchGroupDetail(groupIdNum)
+      .then((data) => { if (!cancelled) setGroup(data); })
+      .catch((err) => { if (!cancelled) setGroupError(err instanceof Error ? err.message : "Failed to load group."); });
+
+    return () => { cancelled = true; };
+  }, [groupIdNum]);
+
+  useEffect(() => {
     let cancelled = false;
 
     async function loadReviewerComments() {
@@ -73,8 +90,6 @@ function NewSubmissionPageContent() {
         }
       } catch (error) {
         if (!cancelled) {
-          // TODO(#156): replace this fallback once the backend review-history
-          // endpoint is available in all environments.
           setReviewerComments([]);
           setCommentsError(error instanceof Error ? error.message : "Reviewer comments could not be loaded.");
         }
@@ -91,10 +106,6 @@ function NewSubmissionPageContent() {
       cancelled = true;
     };
   }, [parentSubmissionId]);
-
-  const rawGroupId = params.groupId;
-  const groupId = Array.isArray(rawGroupId) ? rawGroupId[0] : rawGroupId;
-  const group = mockGroups.find((entry) => String(entry.groupId) === String(groupId));
 
   if (authState === "loading") {
     return (
@@ -118,19 +129,23 @@ function NewSubmissionPageContent() {
     );
   }
 
-  if (!group) {
+  if (groupError) {
     return (
       <main className="flex min-h-screen items-center justify-center bg-gray-950 px-6 text-white">
         <div className="max-w-md rounded-3xl border border-white/10 bg-gray-900/80 p-8 text-center">
           <h1 className="text-xl font-semibold">Group not found</h1>
-          <p className="mt-3 text-sm text-gray-400">We could not find a submission context for this group.</p>
+          <p className="mt-3 text-sm text-gray-400">{groupError}</p>
         </div>
       </main>
     );
   }
 
-  const member = group.members.find((entry) => entry.studentId === studentId);
-  const isLeader = member?.role === "leader";
+  if (!group) {
+    return <SubmissionPageSpinner />;
+  }
+
+  const member = group.members.find((m) => m.studentId === studentId);
+  const isLeader = member?.role === "LEADER";
   const isMemberOfGroup = Boolean(member);
   const disabled = !isLeader;
   const disabledReason = !isMemberOfGroup
@@ -142,7 +157,7 @@ function NewSubmissionPageContent() {
       <div className="mx-auto max-w-4xl space-y-8">
         <div className="space-y-4">
           <div>
-            <Link href={`/groups/${group.groupId}`} className="text-sm text-blue-300 transition-colors hover:text-blue-200">
+            <Link href={`/groups/${group.id}`} className="text-sm text-blue-300 transition-colors hover:text-blue-200">
               {"<- Back to group"}
             </Link>
             <h1 className="mt-6 text-3xl font-bold">
@@ -167,7 +182,7 @@ function NewSubmissionPageContent() {
         </div>
 
         <StudentSubmissionForm
-          groupId={String(group.groupId)}
+          groupId={String(group.id)}
           groupName={group.groupName}
           disabled={disabled}
           disabledReason={disabled ? disabledReason : undefined}

--- a/frontend/app/professor/my-advisees/page.tsx
+++ b/frontend/app/professor/my-advisees/page.tsx
@@ -82,8 +82,8 @@ function MyAdviseesLayout() {
 function AdviseesTable() {
     const [advisees, setAdvisees] = useState<AdvisorAssignment[]>([]);
     const [loading, setLoading] = useState(true);
-    const [releasingId, setReleasingId] = useState<string | null>(null);
-    const [confirmGroupId, setConfirmGroupId] = useState<string | null>(null);
+    const [releasingId, setReleasingId] = useState<number | null>(null);
+    const [confirmGroupId, setConfirmGroupId] = useState<number | null>(null);
 
     useEffect(() => {
         fetchAdvisorAssignments()
@@ -92,7 +92,7 @@ function AdviseesTable() {
             .finally(() => setLoading(false));
     }, []);
 
-    const handleRelease = async (groupId: string) => {
+    const handleRelease = async (groupId: number) => {
         setReleasingId(groupId);
         try {
             await releaseAdviseeGroup(groupId);

--- a/frontend/app/professor/pending-requests/page.tsx
+++ b/frontend/app/professor/pending-requests/page.tsx
@@ -82,9 +82,9 @@ function PendingRequestsLayout() {
 function PendingRequestsTable() {
     const [requests, setRequests] = useState<AdvisorRequestSummary[]>([]);
     const [loading, setLoading] = useState(true);
-    const [rejectingId, setRejectingId] = useState<string | null>(null);
+    const [rejectingId, setRejectingId] = useState<number | null>(null);
     const [rejectReason, setRejectReason] = useState("");
-    const [processingId, setProcessingId] = useState<string | null>(null);
+    const [processingId, setProcessingId] = useState<number | null>(null);
 
     useEffect(() => {
         (async () => {
@@ -99,7 +99,7 @@ function PendingRequestsTable() {
         })();
     }, []);
 
-    const handleApprove = async (requestId: string) => {
+    const handleApprove = async (requestId: number) => {
         setProcessingId(requestId);
         try {
             await submitAdvisorDecision(requestId, { decision: "APPROVE" });
@@ -112,7 +112,7 @@ function PendingRequestsTable() {
         }
     };
 
-    const handleRejectConfirm = async (requestId: string) => {
+    const handleRejectConfirm = async (requestId: number) => {
         setProcessingId(requestId);
         try {
             await submitAdvisorDecision(requestId, {
@@ -130,7 +130,7 @@ function PendingRequestsTable() {
         }
     };
 
-    const openReject = (requestId: string) => {
+    const openReject = (requestId: number) => {
         setRejectingId(requestId);
         setRejectReason("");
     };
@@ -376,7 +376,7 @@ function RequestRow({
     );
 }
 
-function GroupMembers({ teamId }: { teamId: string }) {
+function GroupMembers({ teamId }: { teamId: number }) {
     const [members, setMembers] = useState<{ fullName: string; role: string }[] | null>(null);
 
     useEffect(() => {

--- a/frontend/components/AdvisorRequestPanel.tsx
+++ b/frontend/components/AdvisorRequestPanel.tsx
@@ -19,33 +19,6 @@ type Props = {
     advisorId: number | null;
 };
 
-const mockProfessors: ProfessorDirectoryItem[] = [
-    {
-        userId: 11,
-        fullName: "Dr. Ayse Yilmaz",
-        email: "ayse.yilmaz@yasar.edu.tr",
-        githubUsername: "drayseyilmaz",
-        role: "professor",
-        createdAt: null,
-    },
-    {
-        userId: 12,
-        fullName: "Dr. Mehmet Kaya",
-        email: "mehmet.kaya@yasar.edu.tr",
-        githubUsername: "drmehmetkaya",
-        role: "professor",
-        createdAt: null,
-    },
-    {
-        userId: 17,
-        fullName: "Dr. Selin Aydin",
-        email: "selin.aydin@yasar.edu.tr",
-        githubUsername: "drselinaydin",
-        role: "professor",
-        createdAt: null,
-    },
-];
-
 function getCurrentUserId() {
     const token = getToken();
     const storedUser = getUser();
@@ -82,7 +55,6 @@ export default function AdvisorRequestPanel({
     const [requestingProfessorId, setRequestingProfessorId] = useState<number | null>(null);
     const [withdrawing, setWithdrawing] = useState(false);
     const [confirmOpen, setConfirmOpen] = useState(false);
-    const [usingMockData, setUsingMockData] = useState(false);
 
     const user = getUser();
     const currentUserId = getCurrentUserId();
@@ -108,14 +80,16 @@ export default function AdvisorRequestPanel({
 
                 setProfessors(professorData);
                 setActiveRequest(requestStatus);
-                setUsingMockData(false);
-            } catch {
+            } catch (err) {
                 if (cancelled) return;
 
-                setProfessors(mockProfessors);
+                setProfessors([]);
                 setActiveRequest(null);
-                setUsingMockData(true);
-                setError("");
+                setError(
+                    err instanceof Error
+                        ? err.message
+                        : "Failed to load professors and advisor request status."
+                );
             } finally {
                 if (!cancelled) {
                     setLoading(false);
@@ -139,25 +113,11 @@ export default function AdvisorRequestPanel({
     const requestButtonsDisabled = Boolean(activeRequest) || Boolean(advisorId) || !isLeader;
 
     async function refreshRequestStatus() {
-        if (usingMockData) {
-            return;
-        }
-
         const requestStatus = await fetchAdvisorRequestStatus(groupId);
         setActiveRequest(requestStatus);
     }
 
     async function handleRequestAdvisor(professor: ProfessorDirectoryItem) {
-        if (usingMockData) {
-            setActiveRequest({
-                requestId: Date.now(),
-                professorName: professor.fullName,
-                status: "PENDING",
-            });
-            toast.success(`Mock preview: advisor request sent to ${professor.fullName}.`);
-            return;
-        }
-
         try {
             setRequestingProfessorId(professor.userId);
             await createAdvisorRequest(groupId, professor.userId);
@@ -173,15 +133,6 @@ export default function AdvisorRequestPanel({
     }
 
     async function handleWithdrawRequest() {
-        if (usingMockData) {
-            setWithdrawing(true);
-            setActiveRequest(null);
-            setConfirmOpen(false);
-            setWithdrawing(false);
-            toast.success("Mock preview: advisor request withdrawn successfully.");
-            return;
-        }
-
         try {
             setWithdrawing(true);
             await withdrawAdvisorRequest(groupId);
@@ -225,13 +176,6 @@ export default function AdvisorRequestPanel({
                         )}
                     </div>
                 </div>
-
-                {usingMockData && (
-                    <div className="mt-4 rounded-2xl border border-amber-500/20 bg-amber-500/10 p-4 text-sm text-amber-100">
-                        Preview mode is active because advisor APIs are unavailable from the browser.
-                        Request and withdraw actions are currently simulated with mock data.
-                    </div>
-                )}
 
                 {advisorId ? (
                     <div className="mt-6 rounded-2xl border border-green-500/20 bg-green-500/10 p-5 text-sm text-green-100">

--- a/frontend/components/CommitteeGradingDrawer.tsx
+++ b/frontend/components/CommitteeGradingDrawer.tsx
@@ -137,8 +137,8 @@ export default function CommitteeGradingDrawer({
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          score: Number(gradeInput),
-          comments: comments.trim() || undefined,
+          grade: Number(gradeInput),
+          feedback: comments.trim() || undefined,
         }),
       });
 
@@ -149,7 +149,8 @@ export default function CommitteeGradingDrawer({
           throw new Error(payload);
         }
 
-        throw new Error(payload?.message || payload?.error || `Grade submission failed (${response.status}).`);
+        const errorPayload = payload as { message?: string; error?: string } | null;
+        throw new Error(errorPayload?.message || errorPayload?.error || `Grade submission failed (${response.status}).`);
       }
 
       const successMessage =

--- a/frontend/lib/advisor-api.ts
+++ b/frontend/lib/advisor-api.ts
@@ -87,10 +87,10 @@ export async function fetchAdvisorRequestStatus(groupId: number): Promise<Adviso
 }
 
 export async function createAdvisorRequest(groupId: number, professorId: number): Promise<void> {
-    const res = await fetch(`${API_BASE}/groups/${groupId}/advisor-request`, {
+    const res = await fetch(`${API_BASE}/advisor-requests`, {
         method: "POST",
         headers: getAuthHeaders(),
-        body: JSON.stringify({ professorId }),
+        body: JSON.stringify({ teamId: String(groupId), professorId }),
     });
 
     if (!res.ok) {

--- a/frontend/lib/advisor-requests-api.ts
+++ b/frontend/lib/advisor-requests-api.ts
@@ -6,10 +6,10 @@ const API_BASE =
 export type AdvisorRequestStatus = "PENDING" | "APPROVED" | "REJECTED" | "WITHDRAWN";
 
 export type AdvisorRequestSummary = {
-    id: string;
-    teamId: string;
+    id: number;
+    teamId: number;
     teamName: string;
-    professorId: string;
+    professorId: number;
     professorName: string;
     status: AdvisorRequestStatus;
     message?: string | null;
@@ -31,10 +31,10 @@ export type AdvisorDecisionResponse = {
     status: string;
     message: string;
     data: {
-        requestId: string;
+        requestId: number;
         decision: "APPROVE" | "REJECT";
-        teamId: string;
-        advisorId: string | null;
+        teamId: number;
+        advisorId: number | null;
     };
 };
 
@@ -70,9 +70,9 @@ export async function fetchPendingRequests(): Promise<AdvisorRequestSummary[]> {
 }
 
 export type AdvisorAssignment = {
-    teamId: string;
+    teamId: number;
     teamName: string;
-    advisorId: string | null;
+    advisorId: number | null;
     advisorName: string | null;
     assignedAt: string | null;
     assignmentType: "REQUESTED" | "OVERRIDDEN" | null;
@@ -84,8 +84,8 @@ export type AdvisorAssignmentListResponse = {
 };
 
 export type OverrideAssignmentRequest = {
-    teamId: string;
-    advisorId: string;
+    teamId: number;
+    advisorId: number;
     reason?: string;
 };
 
@@ -118,7 +118,7 @@ export async function overrideAdvisorAssignment(
     }
 }
 
-export async function releaseAdviseeGroup(groupId: string): Promise<void> {
+export async function releaseAdviseeGroup(groupId: number): Promise<void> {
     const res = await fetch(`${API_BASE}/advisor-assignments/${groupId}/release`, {
         method: "POST",
         headers: buildHeaders(),
@@ -130,7 +130,7 @@ export async function releaseAdviseeGroup(groupId: string): Promise<void> {
 }
 
 export async function submitAdvisorDecision(
-    requestId: string,
+    requestId: number,
     payload: AdvisorDecisionRequest
 ): Promise<AdvisorDecisionResponse> {
     const res = await fetch(`${API_BASE}/advisor-requests/${requestId}/decision`, {

--- a/frontend/lib/submissions-api.ts
+++ b/frontend/lib/submissions-api.ts
@@ -7,16 +7,16 @@ export type SubmissionStatus = "PENDING_REVIEW" | "UNDER_REVIEW" | "REVISION_REQ
 export type DeadlineStatus = "APPROACHING" | "OVERDUE";
 
 export interface SubmissionSummary {
-  id: string;
-  teamId: string;
-  teamName: string;
+  id: number;
+  teamId: number;
+  teamName?: string;
   deliverableType: DeliverableType;
   status: SubmissionStatus;
-  assignedCommitteeId: string | null;
-  revisionNumber: number;
+  assignedCommitteeId: number | null;
+  revisionNumber?: number;
   submittedAt: string;
-  deadline: string | null;
-  isOverdue: boolean;
+  deadline?: string | null;
+  isOverdue?: boolean;
 }
 
 export interface SubmissionReview {
@@ -46,8 +46,8 @@ export interface RevisionCreateResponse {
 }
 
 export interface PaginationMeta {
-  page: number;
-  size: number;
+  currentPage: number;
+  pageSize: number;
   totalElements: number;
   totalPages: number;
 }


### PR DESCRIPTION
## What changed

Fixed frontend-to-backend disconnections in Process 3 (Submissions) and Process 4 (Advisor Assignment). No new endpoints, no new pages — only wiring existing frontend to the real backend.

### Process 3 — Submissions
- **CommitteeGradingDrawer**: POST body used `score`/`comments` but backend `GradeSubmissionRequest` expects `grade`/`feedback` — caused 400 on every grade submission
- **submissions-api.ts**: `id`, `teamId`, `assignedCommitteeId` typed as `string` but backend returns `Long` (JSON number); corrected to `number`. Pagination fields renamed from `page`/`size` to `currentPage`/`pageSize` to match backend `SubmissionListResponse`
- **coordinator/submissions page**: Updated pagination field references and added optional field fallbacks (`teamName`, `revisionNumber`, `isOverdue`)
- **submissions/new page**: Group data was loaded from `mockGroups` — any real group ID caused "Group not found". Replaced with `fetchGroupDetail` API call. Also fixed leader role check (`"leader"` → `"LEADER"` to match backend enum)

### Process 4 — Advisor Assignment
- **advisor-requests-api.ts**: All ID fields (`id`, `teamId`, `professorId`, `advisorId`) typed as `string` but backend returns `Long`; corrected to `number`. Updated all function signatures accordingly
- **advisor-api.ts**: `createAdvisorRequest` was calling non-existent `POST /groups/{groupId}/advisor-request`; corrected to real endpoint `POST /advisor-requests` with `{ teamId: string, professorId }` body
- **coordinator/advisor-override page**: Fixed `===` comparison failure caused by string/number mismatch in team selection
- **professor/pending-requests, my-advisees pages**: Updated state and handler types to `number`
- **AdvisorRequestPanel**: Removed silent mock fallback — real API errors are now surfaced to the user

## How to test

1. Log in as a student who is a group leader → go to `/groups/{id}` → advisor request panel should load professors and allow sending a request
2. Log in as a student → go to `/groups/{id}/submissions/new` → form should load (no "Group not found")
3. Log in as coordinator → go to `/coordinator/submissions` → pagination and team names should render correctly
4. Log in as a committee member → open CommitteeGradingDrawer → submit a grade → should return 200 instead of 400
5. Log in as coordinator → go to `/coordinator/advisor-override` → override assignment should work without silent failures