### PR TITLE
Process 4: Add professor active advisees view (#162)

### DIFF
--- a/frontend/app/professor/my-advisees/page.tsx
+++ b/frontend/app/professor/my-advisees/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { getUser, getToken } from "@/lib/auth";
+import { getToken, getUser } from "@/lib/auth";
 import Sidebar from "@/components/Sidebar";
 import {
     fetchAdvisorAssignments,
@@ -18,10 +18,23 @@ export default function MyAdviseesPage() {
     useEffect(() => {
         const token = getToken();
         const user = getUser();
-        if (!token || !user) { router.replace("/auth/login"); return; }
-        if (user.requiresPasswordChange) { router.replace("/auth/change-password"); return; }
-        if (user.role !== "professor") { setRole("denied"); return; }
-        setRole(user.role);
+
+        if (!token || !user) {
+            router.replace("/auth/login");
+            return;
+        }
+
+        if (user.requiresPasswordChange) {
+            router.replace("/auth/change-password");
+            return;
+        }
+
+        if (user.role !== "professor") {
+            queueMicrotask(() => setRole("denied"));
+            return;
+        }
+
+        queueMicrotask(() => setRole(user.role));
     }, [router]);
 
     if (role === null) return <Spinner />;
@@ -68,7 +81,7 @@ function MyAdviseesLayout() {
                     </div>
                     <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10">
                         <div className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
-                        <span className="text-xs text-gray-400">Live</span>
+                        <span className="text-xs text-gray-400">D2 Groups</span>
                     </div>
                 </div>
                 <div className="flex-1 p-8">
@@ -82,22 +95,42 @@ function MyAdviseesLayout() {
 function AdviseesTable() {
     const [advisees, setAdvisees] = useState<AdvisorAssignment[]>([]);
     const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
     const [releasingId, setReleasingId] = useState<number | null>(null);
     const [confirmGroupId, setConfirmGroupId] = useState<number | null>(null);
 
-    useEffect(() => {
-        fetchAdvisorAssignments()
-            .then((data) => setAdvisees(data.filter((a) => a.advisorId !== null)))
-            .catch(() => toast.error("Failed to load advisees."))
-            .finally(() => setLoading(false));
+    const loadAdvisees = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+
+        try {
+            const data = await fetchAdvisorAssignments({ hasAdvisor: true });
+            setAdvisees(data);
+        } catch (err: unknown) {
+            const message = err instanceof Error ? err.message : "Failed to load active advisees.";
+            setError(message);
+            toast.error(message);
+        } finally {
+            setLoading(false);
+        }
     }, []);
+
+    useEffect(() => {
+        loadAdvisees();
+    }, [loadAdvisees]);
+
+    const selectedGroup = useMemo(
+        () => advisees.find((a) => a.teamId === confirmGroupId),
+        [advisees, confirmGroupId]
+    );
 
     const handleRelease = async (groupId: number) => {
         setReleasingId(groupId);
+
         try {
             await releaseAdviseeGroup(groupId);
             toast.success("Group released successfully. The group leader has been notified.");
-            setAdvisees((prev) => prev.filter((a) => a.teamId !== groupId));
+            await loadAdvisees();
         } catch (err: unknown) {
             toast.error(err instanceof Error ? err.message : "Failed to release group.");
         } finally {
@@ -117,6 +150,30 @@ function AdviseesTable() {
         );
     }
 
+    if (error) {
+        return (
+            <div className="bg-gray-900 border border-red-500/20 rounded-2xl p-8 flex items-start justify-between gap-6">
+                <div className="flex items-start gap-4">
+                    <div className="w-10 h-10 rounded-xl bg-red-500/10 border border-red-500/20 flex items-center justify-center shrink-0">
+                        <svg className="w-5 h-5 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v3.75m0 3.75h.008v.008H12v-.008zm8.25-3.75A8.25 8.25 0 113.75 12a8.25 8.25 0 0116.5 0z" />
+                        </svg>
+                    </div>
+                    <div>
+                        <p className="text-sm font-semibold text-white">Active advisees could not be loaded</p>
+                        <p className="text-sm text-gray-400 mt-1">{error}</p>
+                    </div>
+                </div>
+                <button
+                    onClick={loadAdvisees}
+                    className="px-4 py-2 rounded-lg text-sm font-medium bg-white/5 border border-white/10 text-gray-300 hover:text-white hover:bg-white/10 transition-colors"
+                >
+                    Retry
+                </button>
+            </div>
+        );
+    }
+
     if (advisees.length === 0) {
         return (
             <div className="bg-gray-900 border border-white/8 rounded-2xl p-12 flex flex-col items-center justify-center gap-3">
@@ -126,7 +183,7 @@ function AdviseesTable() {
                     </svg>
                 </div>
                 <p className="text-sm font-medium text-white">No active advisees</p>
-                <p className="text-xs text-gray-500">Groups assigned to you will appear here.</p>
+                <p className="text-xs text-gray-500">Groups assigned to you in D2 will appear here.</p>
             </div>
         );
     }
@@ -134,7 +191,7 @@ function AdviseesTable() {
     return (
         <>
             <div className="bg-gray-900 border border-white/8 rounded-2xl overflow-hidden">
-                <div className="px-6 py-4 border-b border-white/5 flex items-center justify-between">
+                <div className="px-6 py-4 border-b border-white/5 flex items-center justify-between gap-4">
                     <div className="flex items-center gap-3">
                         <div className="w-8 h-8 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-center">
                             <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -143,91 +200,134 @@ function AdviseesTable() {
                         </div>
                         <div>
                             <p className="text-sm font-semibold text-white">Active Advisee Groups</p>
-                            <p className="text-xs text-gray-500">{advisees.length} group{advisees.length !== 1 ? "s" : ""} currently assigned</p>
+                            <p className="text-xs text-gray-500">
+                                {advisees.length} group{advisees.length !== 1 ? "s" : ""} currently assigned
+                            </p>
                         </div>
                     </div>
-                    <span className="text-xs font-medium text-blue-400 bg-blue-400/10 border border-blue-400/20 px-2.5 py-1 rounded-full">
-                        {advisees.length} Active
-                    </span>
+                    <button
+                        onClick={loadAdvisees}
+                        className="px-3 py-1.5 rounded-lg text-xs font-medium bg-white/5 border border-white/10 text-gray-300 hover:text-white hover:bg-white/10 transition-colors"
+                    >
+                        Refresh
+                    </button>
                 </div>
 
                 <div className="overflow-x-auto">
-                    <table className="w-full">
+                    <table className="w-full min-w-[900px]">
                         <thead>
                             <tr className="border-b border-white/5">
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Group</th>
+                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Leader</th>
+                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assigned</th>
-                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
+                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Source</th>
                                 <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                             </tr>
                         </thead>
                         <tbody className="divide-y divide-white/5">
-                            {advisees.map((a) => (
-                                <tr key={a.teamId} className="hover:bg-white/[0.02] transition-colors">
-                                    <td className="px-6 py-4">
-                                        <div className="flex items-center gap-3">
-                                            <div className="w-8 h-8 rounded-lg bg-blue-600/10 border border-blue-500/20 flex items-center justify-center shrink-0">
-                                                <span className="text-xs font-bold text-blue-400 uppercase">
-                                                    {a.teamName.slice(0, 2)}
-                                                </span>
+                            {advisees.map((assignment) => {
+                                const status = assignment.status?.toUpperCase() ?? "UNKNOWN";
+                                const canRelease = status === "ADVISED";
+
+                                return (
+                                    <tr key={assignment.teamId} className="hover:bg-white/[0.02] transition-colors">
+                                        <td className="px-6 py-4">
+                                            <div className="flex items-center gap-3">
+                                                <div className="w-8 h-8 rounded-lg bg-blue-600/10 border border-blue-500/20 flex items-center justify-center shrink-0">
+                                                    <span className="text-xs font-bold text-blue-400 uppercase">
+                                                        {getInitials(assignment.teamName)}
+                                                    </span>
+                                                </div>
+                                                <div className="min-w-0">
+                                                    <p className="text-sm font-medium text-white truncate">{assignment.teamName}</p>
+                                                    <p className="text-xs text-gray-600">Group #{assignment.teamId}</p>
+                                                </div>
                                             </div>
-                                            <p className="text-sm font-medium text-white">{a.teamName}</p>
-                                        </div>
-                                    </td>
-                                    <td className="px-6 py-4 text-sm text-gray-400">
-                                        {a.assignedAt ? formatRelativeDate(a.assignedAt) : "—"}
-                                    </td>
-                                    <td className="px-6 py-4">
-                                        {a.assignmentType ? (
-                                            <span className={`text-xs font-medium px-2 py-0.5 rounded-full border ${
-                                                a.assignmentType === "OVERRIDDEN"
-                                                    ? "text-orange-400 bg-orange-400/10 border-orange-400/20"
-                                                    : "text-blue-400 bg-blue-400/10 border-blue-400/20"
-                                            }`}>
-                                                {a.assignmentType}
-                                            </span>
-                                        ) : <span className="text-xs text-gray-600">—</span>}
-                                    </td>
-                                    <td className="px-6 py-4 text-right">
-                                        <button
-                                            onClick={() => setConfirmGroupId(a.teamId)}
-                                            disabled={releasingId === a.teamId}
-                                            className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg text-xs font-medium ml-auto
-                                                       bg-red-600/10 border border-red-500/30 text-red-400
-                                                       hover:bg-red-600/20 hover:border-red-500/50 active:scale-95
-                                                       transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                                        >
-                                            {releasingId === a.teamId ? (
-                                                <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
-                                                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                                                </svg>
-                                            ) : (
-                                                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15" />
-                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 12H9m0 0l3-3m-3 3l3 3" />
-                                                </svg>
-                                            )}
-                                            Release Group
-                                        </button>
-                                    </td>
-                                </tr>
-                            ))}
+                                        </td>
+                                        <td className="px-6 py-4 text-sm text-gray-300">
+                                            {assignment.leaderName || "Not available"}
+                                        </td>
+                                        <td className="px-6 py-4">
+                                            <StatusPill status={status} />
+                                        </td>
+                                        <td className="px-6 py-4 text-sm text-gray-400">
+                                            {assignment.assignedAt ? formatRelativeDate(assignment.assignedAt) : "Not tracked"}
+                                        </td>
+                                        <td className="px-6 py-4">
+                                            <AssignmentTypePill assignmentType={assignment.assignmentType} />
+                                        </td>
+                                        <td className="px-6 py-4 text-right">
+                                            <button
+                                                onClick={() => setConfirmGroupId(assignment.teamId)}
+                                                disabled={releasingId === assignment.teamId || !canRelease}
+                                                title={canRelease ? "Release this advisee group" : "Only advised groups can be released"}
+                                                className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg text-xs font-medium ml-auto
+                                                           bg-red-600/10 border border-red-500/30 text-red-400
+                                                           hover:bg-red-600/20 hover:border-red-500/50 active:scale-95
+                                                           transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                                            >
+                                                {releasingId === assignment.teamId ? (
+                                                    <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                                    </svg>
+                                                ) : (
+                                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15" />
+                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 12H9m0 0l3-3m-3 3l3 3" />
+                                                    </svg>
+                                                )}
+                                                Release
+                                            </button>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
                         </tbody>
                     </table>
                 </div>
             </div>
 
-            {/* Confirm Release Modal */}
-            {confirmGroupId && (
+            {confirmGroupId && selectedGroup && (
                 <ConfirmReleaseModal
-                    groupName={advisees.find((a) => a.teamId === confirmGroupId)?.teamName ?? ""}
+                    groupName={selectedGroup.teamName}
                     processing={releasingId === confirmGroupId}
                     onConfirm={() => handleRelease(confirmGroupId)}
                     onCancel={() => setConfirmGroupId(null)}
                 />
             )}
         </>
+    );
+}
+
+function StatusPill({ status }: { status: string }) {
+    const styles =
+        status === "ADVISED"
+            ? "text-green-400 bg-green-400/10 border-green-400/20"
+            : "text-gray-400 bg-white/5 border-white/10";
+
+    return (
+        <span className={`text-xs font-medium px-2 py-0.5 rounded-full border ${styles}`}>
+            {formatEnumLabel(status)}
+        </span>
+    );
+}
+
+function AssignmentTypePill({ assignmentType }: { assignmentType: AdvisorAssignment["assignmentType"] }) {
+    if (!assignmentType) {
+        return <span className="text-xs text-gray-600">Pending backend metadata</span>;
+    }
+
+    const styles =
+        assignmentType === "OVERRIDDEN"
+            ? "text-orange-400 bg-orange-400/10 border-orange-400/20"
+            : "text-blue-400 bg-blue-400/10 border-blue-400/20";
+
+    return (
+        <span className={`text-xs font-medium px-2 py-0.5 rounded-full border ${styles}`}>
+            {formatEnumLabel(assignmentType)}
+        </span>
     );
 }
 
@@ -293,12 +393,40 @@ function ConfirmReleaseModal({
 }
 
 function formatRelativeDate(isoString: string): string {
-    const diff = Date.now() - new Date(isoString).getTime();
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return "Invalid date";
+
+    const diff = Date.now() - date.getTime();
+    if (diff < 0) return date.toLocaleDateString("tr-TR", { day: "2-digit", month: "short" });
+
     const minutes = Math.floor(diff / 60000);
+    if (minutes < 1) return "Just now";
     if (minutes < 60) return `${minutes}m ago`;
+
     const hours = Math.floor(minutes / 60);
     if (hours < 24) return `${hours}h ago`;
+
     const days = Math.floor(hours / 24);
     if (days < 7) return `${days}d ago`;
-    return new Date(isoString).toLocaleDateString("tr-TR", { day: "2-digit", month: "short" });
+
+    return date.toLocaleDateString("tr-TR", { day: "2-digit", month: "short" });
+}
+
+function getInitials(value: string): string {
+    const initials = value
+        .split(/\s+/)
+        .filter(Boolean)
+        .slice(0, 2)
+        .map((part) => part[0])
+        .join("");
+
+    return initials || "G";
+}
+
+function formatEnumLabel(value: string): string {
+    return value
+        .toLowerCase()
+        .split("_")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ");
 }

--- a/frontend/lib/advisor-requests-api.ts
+++ b/frontend/lib/advisor-requests-api.ts
@@ -72,8 +72,12 @@ export async function fetchPendingRequests(): Promise<AdvisorRequestSummary[]> {
 export type AdvisorAssignment = {
     teamId: number;
     teamName: string;
+    leaderName: string;
     advisorId: number | null;
     advisorName: string | null;
+    status: string;
+    // TODO(P4-ASSIGN-2 backend): assignedAt and assignmentType are currently
+    // returned as null until assignment metadata is persisted or derived.
     assignedAt: string | null;
     assignmentType: "REQUESTED" | "OVERRIDDEN" | null;
 };
@@ -89,8 +93,20 @@ export type OverrideAssignmentRequest = {
     reason?: string;
 };
 
-export async function fetchAdvisorAssignments(): Promise<AdvisorAssignment[]> {
-    const res = await fetch(`${API_BASE}/advisor-assignments`, {
+export type FetchAdvisorAssignmentsOptions = {
+    advisorId?: number;
+    hasAdvisor?: boolean;
+};
+
+export async function fetchAdvisorAssignments(
+    options: FetchAdvisorAssignmentsOptions = {}
+): Promise<AdvisorAssignment[]> {
+    const params = new URLSearchParams();
+    if (options.advisorId != null) params.set("advisorId", String(options.advisorId));
+    if (options.hasAdvisor != null) params.set("hasAdvisor", String(options.hasAdvisor));
+
+    const query = params.toString();
+    const res = await fetch(`${API_BASE}/advisor-assignments${query ? `?${query}` : ""}`, {
         method: "GET",
         headers: buildHeaders(),
         cache: "no-store",


### PR DESCRIPTION
## Implementation
- Connect the professor My Advisees page to the advisor assignments endpoint backed by D2 groups.
- Render active advisee groups in a data table with leader, status, assignment metadata, and Release action.
- Refresh the assignment list from the backend after a successful release and show loading, empty, and error states.

## Backend TODO
- `assignedAt` and `assignmentType` are still returned as `null`; frontend keeps a TODO for P4-ASSIGN-2 until backend persists or derives assignment metadata.

## Verification
- `npx.cmd eslint app/professor/my-advisees/page.tsx lib/advisor-requests-api.ts`
- `npx.cmd tsc --noEmit`
- `npm.cmd run build` reaches compile and TypeScript, then fails on an existing `/groups` Suspense boundary prerender issue unrelated to this change.
