### PR TITLE
feat: GitHub integration UI with bind, unbind and connection test

### DIFF
--- a/frontend/app/groups/[groupId]/integrations/github/page.tsx
+++ b/frontend/app/groups/[groupId]/integrations/github/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Sidebar from "@/components/Sidebar";
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
@@ -10,6 +11,11 @@ import ConfirmDialog from "@/components/ConfirmDialog";
 import AppTopbar from "@/components/AppTopbar";
 import { fetchGroupDetail } from "@/lib/groups-api";
 import { fetchGithubIntegration, type GithubIntegrationApiResponse } from "@/lib/integrations-api";
+import {
+    bindGithubIntegration,
+    unbindGithubIntegration,
+    testIntegrations,
+} from "@/lib/integrations-api";
 import { getUser } from "@/lib/auth";
 
 export default function GithubIntegrationPage() {
@@ -76,30 +82,42 @@ export default function GithubIntegrationPage() {
     const isLeader = group.leaderId === currentUser?.userId;
 
     async function handleBind(githubPat: string, organizationName: string) {
-        console.log("Bind request:", { githubPat, organizationName });
+        try {
+            await bindGithubIntegration(groupId, githubPat, organizationName);
 
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+            setStatusMessage(`GitHub organization "${organizationName}" bound successfully.`);
 
-        setStatusMessage(`GitHub organization "${organizationName}" bound successfully.`);
+            const updated = await fetchGithubIntegration(groupId);
+            setIntegration(updated);
+        } catch (err: any) {
+            setStatusMessage(err.message || "Failed to bind GitHub.");
+        }
     }
 
     async function handleUnbind() {
         setUnbindLoading(true);
 
         try {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            await unbindGithubIntegration(groupId);
+
             setStatusMessage("GitHub organization unbound successfully.");
             setShowConfirm(false);
+
+            const updated = await fetchGithubIntegration(groupId);
+            setIntegration(updated);
+        } catch (err: any) {
+            setStatusMessage(err.message || "Failed to unbind GitHub.");
         } finally {
             setUnbindLoading(false);
         }
     }
 
     return (
-        <>
-            <main className="min-h-screen bg-gray-950 px-6 py-10 text-white">
+        <div className="min-h-screen bg-gray-950 flex">
+            <Sidebar activePage="groups" />
+            <main className="flex-1 min-w-0 px-6 py-10 text-white">
                 <div className="mx-auto max-w-4xl space-y-8">
-                    <AppTopbar />
+                    <AppTopbar hideNotification />
 
                     <Link
                         href={`/groups/${groupId}`}
@@ -157,6 +175,9 @@ export default function GithubIntegrationPage() {
 
                             <IntegrationTestCard
                                 groupId={groupId}
+                                onTest={async () => {
+                                    return await testIntegrations(groupId);
+                                }}
                             />
                         </>
                     ) : (
@@ -177,6 +198,6 @@ export default function GithubIntegrationPage() {
                 onConfirm={handleUnbind}
                 onCancel={() => setShowConfirm(false)}
             />
-        </>
+        </div>
     );
 }

--- a/frontend/app/groups/[groupId]/integrations/github/page.tsx
+++ b/frontend/app/groups/[groupId]/integrations/github/page.tsx
@@ -79,7 +79,14 @@ export default function GithubIntegrationPage() {
         );
     }
 
-    const isLeader = group.leaderId === currentUser?.userId;
+    const isLeader = group?.leaderId === currentUser?.userId;
+
+    const githubStatus = integration?.data?.status?.toLowerCase();
+
+    const isGithubConnected =
+        !!integration?.data?.organizationName &&
+        githubStatus !== "inactive" &&
+        githubStatus !== "error";
 
     async function handleBind(githubPat: string, organizationName: string) {
         try {
@@ -112,6 +119,7 @@ export default function GithubIntegrationPage() {
         }
     }
 
+
     return (
         <div className="min-h-screen bg-gray-950 flex">
             <Sidebar activePage="groups" />
@@ -139,19 +147,16 @@ export default function GithubIntegrationPage() {
                         </div>
                     )}
 
-                    <GithubStatusCard
-                        integration={
-                            integration?.data?.status === "inactive"
-                                ? undefined
-                                : integration?.data
-                        }
-                    />
+                    <GithubStatusCard integration={integration?.data} />
 
                     {isLeader ? (
                         <>
-                            <GithubBindForm onBind={handleBind} />
 
-                            {integration?.data?.status === "active" && (
+                            {!isGithubConnected && (
+                                <GithubBindForm onBind={handleBind} />
+                            )}
+
+                            {isGithubConnected && (
                                 <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-6 shadow-lg shadow-black/20 backdrop-blur">
                                     <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                                         <div>

--- a/frontend/app/groups/[groupId]/page.tsx
+++ b/frontend/app/groups/[groupId]/page.tsx
@@ -358,13 +358,17 @@ export default function GroupDetailPage() {
                             </div>
                         </Link>
 
-                        <GithubStatusCard
-                            integration={
-                                githubIntegration?.data?.status === "inactive"
-                                    ? undefined
-                                    : githubIntegration?.data
-                            }
-                        />
+                        <Link href={`/groups/${group.id}/integrations/github`}>
+                            <div className="cursor-pointer">
+                                <GithubStatusCard
+                                    integration={
+                                        githubIntegration?.data?.status === "inactive"
+                                            ? undefined
+                                            : githubIntegration?.data
+                                    }
+                                />
+                            </div>
+                        </Link>
 
                         <JiraStatusCard
                             integration={

--- a/frontend/app/groups/page.tsx
+++ b/frontend/app/groups/page.tsx
@@ -11,9 +11,29 @@ import {
     createGroupApi,
     ApiGroupListItem,
 } from "@/lib/groups-api";
+import {
+    fetchGithubIntegration,
+    fetchJiraIntegration,
+} from "@/lib/integrations-api";
 import { Group } from "@/lib/group-types";
 import { getUser, getToken, decodeToken } from "@/lib/auth";
 import { showToast } from "@/components/toast/ToastContext";
+
+function isIntegrationConnected(data?: {
+    status?: string | null;
+    organizationName?: string | null;
+    jiraSpaceUrl?: string | null;
+    projectKey?: string | null;
+} | null) {
+    const status = data?.status?.toLowerCase();
+
+    return (
+        !!data &&
+        status !== "inactive" &&
+        status !== "error" &&
+        (!!data.organizationName || !!data.jiraSpaceUrl || !!data.projectKey)
+    );
+}
 
 function mapApiGroupToUiGroup(apiGroup: ApiGroupListItem): Group {
     return {
@@ -105,7 +125,27 @@ export default function GroupsPage() {
 
                 if (cancelled) return;
 
-                const mappedGroups = response.content.map(mapApiGroupToUiGroup);
+                const mappedGroups = await Promise.all(
+                    response.content.map(async (apiGroup) => {
+                        const uiGroup = mapApiGroupToUiGroup(apiGroup);
+
+                        try {
+                            const [githubIntegration, jiraIntegration] = await Promise.all([
+                                fetchGithubIntegration(apiGroup.id),
+                                fetchJiraIntegration(apiGroup.id),
+                            ]);
+
+                            return {
+                                ...uiGroup,
+                                githubBound: isIntegrationConnected(githubIntegration.data),
+                                jiraBound: isIntegrationConnected(jiraIntegration.data),
+                            };
+                        } catch {
+                            return uiGroup;
+                        }
+                    })
+                );
+
                 setGroups(mappedGroups);
                 setTotalPages(Math.max(response.totalPages, 1));
 
@@ -187,7 +227,27 @@ export default function GroupsPage() {
             updateParams({ page: 0 });
 
             const response = await fetchGroups(0, pageSize, statusFilter, searchQuery, advisorFilter);
-            const mappedGroups = response.content.map(mapApiGroupToUiGroup);
+            const mappedGroups = await Promise.all(
+                response.content.map(async (apiGroup) => {
+                    const uiGroup = mapApiGroupToUiGroup(apiGroup);
+
+                    try {
+                        const [githubIntegration, jiraIntegration] = await Promise.all([
+                            fetchGithubIntegration(apiGroup.id),
+                            fetchJiraIntegration(apiGroup.id),
+                        ]);
+
+                        return {
+                            ...uiGroup,
+                            githubBound: isIntegrationConnected(githubIntegration.data),
+                            jiraBound: isIntegrationConnected(jiraIntegration.data),
+                        };
+                    } catch {
+                        return uiGroup;
+                    }
+                })
+            );
+
             setGroups(mappedGroups);
             setTotalPages(Math.max(response.totalPages, 1));
             setOwnGroupId(createdGroup.id);

--- a/frontend/components/GithubStatusCard.tsx
+++ b/frontend/components/GithubStatusCard.tsx
@@ -22,16 +22,15 @@ export default function GithubStatusCard({ integration }: Props) {
     };
 
     return (
-        <div className="bg-gray-900/80 border border-white/10 rounded-2xl p-6 shadow-lg">
-
+        <div className="rounded-2xl border border-blue-500/20 bg-blue-500/10 p-6 shadow-lg shadow-blue-950/20 backdrop-blur transition-all hover:border-blue-400/40 hover:bg-blue-500/15">
             {/* Title */}
             <div className="flex items-center justify-between mb-4">
                 <h3 className="text-sm text-gray-400">GitHub Integration</h3>
 
                 <span
                     className={`text-xs px-3 py-1 rounded-full font-medium ${isConnected
-                            ? "bg-green-500/15 text-green-400"
-                            : "bg-gray-700 text-gray-400"
+                        ? "bg-green-500/15 text-green-400"
+                        : "bg-gray-700 text-gray-400"
                         }`}
                 >
                     {isConnected ? "Connected" : "Not Connected"}

--- a/frontend/components/GithubStatusCard.tsx
+++ b/frontend/components/GithubStatusCard.tsx
@@ -11,7 +11,13 @@ type Props = {
 };
 
 export default function GithubStatusCard({ integration }: Props) {
-    const isConnected = integration?.status === "active";
+    const status = integration?.status?.toLowerCase();
+
+    const isConnected =
+        !!integration &&
+        !!integration.organizationName &&
+        status !== "inactive" &&
+        status !== "error";
 
     const formatDate = (date?: string | null) => {
         if (!date) return "-";

--- a/frontend/components/IntegrationTestCard.tsx
+++ b/frontend/components/IntegrationTestCard.tsx
@@ -1,31 +1,27 @@
 "use client";
 
 import { useState } from "react";
-import { IntegrationTestResult } from "@/lib/github-types";
+import { type IntegrationsTestResponse } from "@/lib/integrations-api";
 
 type Props = {
     groupId: number;
-    mockResult?: IntegrationTestResult;
+    onTest: () => Promise<IntegrationsTestResponse>;
 };
 
-export default function IntegrationTestCard({ groupId, mockResult }: Props) {
+export default function IntegrationTestCard({ groupId, onTest }: Props) {
     const [loading, setLoading] = useState(false);
-    const [result, setResult] = useState<IntegrationTestResult | null>(null);
+    const [result, setResult] = useState<IntegrationsTestResponse | null>(null);
 
     async function handleTest() {
         setLoading(true);
 
         try {
-            await new Promise((r) => setTimeout(r, 1000));
-
-            if (mockResult) {
-                setResult(mockResult);
-            }
+            const res = await onTest();
+            setResult(res);
         } finally {
             setLoading(false);
         }
     }
-
     return (
         <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-6 shadow-lg shadow-black/20 backdrop-blur">
             <div className="mb-4 flex items-center justify-between">

--- a/frontend/components/IntegrationTestCard.tsx
+++ b/frontend/components/IntegrationTestCard.tsx
@@ -17,6 +17,7 @@ export default function IntegrationTestCard({ groupId, onTest }: Props) {
 
         try {
             const res = await onTest();
+            console.log("Integration test response:", res);
             setResult(res);
         } finally {
             setLoading(false);

--- a/frontend/lib/integrations-api.ts
+++ b/frontend/lib/integrations-api.ts
@@ -99,3 +99,72 @@ export async function fetchJiraIntegration(
 
     return res.json();
 }
+
+export type IntegrationsTestResponse = {
+    github: {
+        connected: boolean;
+        message: string;
+    };
+    jira: {
+        connected: boolean;
+        message: string;
+    };
+};
+
+export async function bindGithubIntegration(
+    groupId: number,
+    githubPat: string,
+    organizationName: string
+): Promise<void> {
+    const token = getToken();
+
+    const res = await fetch(`${API_BASE}/groups/${groupId}/integrations/github`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token ?? ""}`,
+        },
+        body: JSON.stringify({
+            githubPat,
+            organizationName,
+        }),
+    });
+
+    if (!res.ok) {
+        throw new Error(await parseError(res));
+    }
+}
+
+export async function unbindGithubIntegration(groupId: number): Promise<void> {
+    const token = getToken();
+
+    const res = await fetch(`${API_BASE}/groups/${groupId}/integrations/github`, {
+        method: "DELETE",
+        headers: {
+            Authorization: `Bearer ${token ?? ""}`,
+        },
+    });
+
+    if (!res.ok) {
+        throw new Error(await parseError(res));
+    }
+}
+
+export async function testIntegrations(
+    groupId: number
+): Promise<IntegrationsTestResponse> {
+    const token = getToken();
+
+    const res = await fetch(`${API_BASE}/groups/${groupId}/integrations/test`, {
+        method: "POST",
+        headers: {
+            Authorization: `Bearer ${token ?? ""}`,
+        },
+    });
+
+    if (!res.ok) {
+        throw new Error(await parseError(res));
+    }
+
+    return res.json();
+}


### PR DESCRIPTION
Implements GitHub Integration UI for group management.

### Features
- Bind GitHub organization (PAT + organization name)
- View integration status
- Unbind with confirmation dialog
- Test connection (GitHub + JIRA)

### API Endpoints
- POST /integrations/github
- GET /integrations/github
- DELETE /integrations/github
- POST /integrations/test

### Notes
- PAT input is masked
- Only group leader can manage integration

Closes #23