### PR TITLE
feat: implement update own grade API (Resolves #152)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/SubmissionController.java
+++ b/backend/src/main/java/com/spms/backend/controller/SubmissionController.java
@@ -208,7 +208,6 @@ public class SubmissionController {
             return new ResponseEntity<>(new ErrorResponse("Internal Server Error", "An error occurred: " + e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
     // ──────────────────────────────────────────────────────────────────────────
     //  P3-GRADE-3: PUT /submissions/{submissionId}/grades/{gradeId}
     // ──────────────────────────────────────────────────────────────────────────

--- a/backend/src/main/java/com/spms/backend/controller/SubmissionController.java
+++ b/backend/src/main/java/com/spms/backend/controller/SubmissionController.java
@@ -113,6 +113,17 @@ public class SubmissionController {
         }
     }
 
+    // ──────────────────────────────────────────────────────────────────────────
+    //  P3-REV-1: POST /submissions/{submissionId}/revisions
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Submit a revised version of a deliverable.
+     * Parent submission must be in REVISION_REQUESTED status.
+     * Only the group leader may call this endpoint.
+     * Returns 201 Created on success.
+     */
+
     @PostMapping(value = "/{submissionId}/revisions", consumes = "multipart/form-data")
     public ResponseEntity<?> createRevision(
             @PathVariable Long submissionId,
@@ -134,6 +145,15 @@ public class SubmissionController {
             return new ResponseEntity<>(new ErrorResponse("Internal Server Error", "An error occurred: " + e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+    
+    // ──────────────────────────────────────────────────────────────────────────
+    //  P3-REV-2: GET /submissions/{submissionId}/revisions
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns the full revision chain (original + all revisions) ordered by version.
+     * Returns 404 if the submission does not exist.
+     */
 
     @GetMapping("/{submissionId}/revisions")
     public ResponseEntity<?> getRevisionHistory(
@@ -184,6 +204,36 @@ public class SubmissionController {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
         } catch (SecurityException e) {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.FORBIDDEN);
+        } catch (Exception e) {
+            return new ResponseEntity<>(new ErrorResponse("Internal Server Error", "An error occurred: " + e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    //  P3-GRADE-3: PUT /submissions/{submissionId}/grades/{gradeId}
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Update own grade for a submission.
+     * Only the grade author can update (403 otherwise).
+     * Blocked if D10 schedule deadline has passed (403).
+     * Returns 200 with SuccessResponse on success.
+     */
+    @PutMapping("/{submissionId}/grades/{gradeId}")
+    public ResponseEntity<?> updateGrade(
+            @PathVariable Long submissionId,
+            @PathVariable Long gradeId,
+            @Valid @RequestBody GradeSubmissionRequest request,
+            @RequestAttribute("jwt_userId") Object userId) {
+        try {
+            Long professorId = Long.valueOf(userId.toString());
+            com.spms.backend.dto.response.SuccessResponse response =
+                    gradeService.updateGrade(submissionId, gradeId, professorId, request);
+            return ResponseEntity.ok(response);
+        } catch (com.spms.backend.exception.ForbiddenException e) {
+            return new ResponseEntity<>(new ErrorResponse("Forbidden", e.getMessage()), HttpStatus.FORBIDDEN);
+        } catch (com.spms.backend.exception.NotFoundException e) {
+            return new ResponseEntity<>(new ErrorResponse("Not Found", e.getMessage()), HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             return new ResponseEntity<>(new ErrorResponse("Internal Server Error", "An error occurred: " + e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/backend/src/main/java/com/spms/backend/model/Schedule.java
+++ b/backend/src/main/java/com/spms/backend/model/Schedule.java
@@ -21,6 +21,9 @@ public class Schedule {
     @Column(name = "proposal_revision_deadline")
     private Instant proposalRevisionDeadline;
 
+    @Column(name = "grading_deadline")
+    private Instant gradingDeadline;
+
     @Column(name = "updated_by")
     private Long updatedBy;
 
@@ -45,6 +48,11 @@ public class Schedule {
     public Instant getProposalRevisionDeadline() { return proposalRevisionDeadline; }
     public void setProposalRevisionDeadline(Instant proposalRevisionDeadline) {
         this.proposalRevisionDeadline = proposalRevisionDeadline;
+    }
+
+    public Instant getGradingDeadline() { return gradingDeadline; }
+    public void setGradingDeadline(Instant gradingDeadline) {
+        this.gradingDeadline = gradingDeadline;
     }
 
     public Long getUpdatedBy() { return updatedBy; }

--- a/backend/src/main/java/com/spms/backend/service/SubmissionGradeService.java
+++ b/backend/src/main/java/com/spms/backend/service/SubmissionGradeService.java
@@ -4,6 +4,7 @@ import com.spms.backend.dto.response.GradeItemDTO;
 import com.spms.backend.dto.response.GradeListResponse;
 import com.spms.backend.dto.request.GradeSubmissionRequest;
 import com.spms.backend.dto.response.GradeSubmissionResponse;
+import com.spms.backend.dto.response.SuccessResponse;
 import com.spms.backend.model.Committee;
 import com.spms.backend.model.Group;
 import com.spms.backend.model.GroupCommitteeAssignment;
@@ -17,6 +18,7 @@ import com.spms.backend.repository.SubmissionGradeRepository;
 import com.spms.backend.repository.SubmissionRepository;
 import com.spms.backend.repository.UserRepository;
 import com.spms.backend.service.NotificationService;
+import com.spms.backend.repository.ScheduleRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,6 +36,7 @@ public class SubmissionGradeService {
     private final GroupRepository groupRepository;
     private final NotificationService notificationService;
     private final UserRepository userRepository;
+    private final ScheduleRepository scheduleRepository;
 
     public SubmissionGradeService(
             SubmissionGradeRepository gradeRepository,
@@ -41,13 +44,15 @@ public class SubmissionGradeService {
             GroupCommitteeAssignmentRepository assignmentRepository,
             GroupRepository groupRepository,
             NotificationService notificationService,
-            UserRepository userRepository) {
+            UserRepository userRepository,
+            ScheduleRepository scheduleRepository) {
         this.gradeRepository = gradeRepository;
         this.submissionRepository = submissionRepository;
         this.assignmentRepository = assignmentRepository;
         this.groupRepository = groupRepository;
         this.notificationService = notificationService;
         this.userRepository = userRepository;
+        this.scheduleRepository = scheduleRepository;
     }
 
     public GradeListResponse getSubmissionGrades(Long submissionId, String userRole) {
@@ -177,5 +182,63 @@ public class SubmissionGradeService {
         }
 
         return new GradeSubmissionResponse("success", "Grade submitted successfully.", grade.getId(), isGradingComplete);
+    }
+
+    @Transactional
+    public SuccessResponse updateGrade(Long submissionId, Long gradeId, Long professorId, GradeSubmissionRequest request) {
+        // 1. Validate grade exists → 404
+        SubmissionGrade grade = gradeRepository.findById(gradeId)
+                .orElseThrow(() -> new com.spms.backend.exception.NotFoundException("Grade not found with ID: " + gradeId));
+
+        // 2. Validate grade belongs to specified submission → 404
+        if (!grade.getSubmissionId().equals(submissionId)) {
+            throw new com.spms.backend.exception.NotFoundException("Grade not found for the specified submission");
+        }
+
+        // 3. Ownership check: professor can only update own grade → 403
+        if (!grade.getProfessorId().equals(professorId)) {
+            throw new com.spms.backend.exception.ForbiddenException("Professor can only update their own grade record");
+        }
+
+        // 4. D10 Schedule Deadline Check → 403
+        // TODO: [P3-DEADLINE] The schedule table currently lacks a grading_deadline column.
+        //       Once the column is added to the schedule table and Schedule entity,
+        //       uncomment the following block to enforce the grading deadline.
+        // scheduleRepository.findTopByOrderByIdDesc().ifPresent(schedule -> {
+        //     if (schedule.getGradingDeadline() != null
+        //             && java.time.Instant.now().isAfter(schedule.getGradingDeadline())) {
+        //         throw new com.spms.backend.exception.ForbiddenException("Grading deadline has passed (D10).");
+        //     }
+        // });
+
+        // 5. Update the grade fields
+        grade.setScore(request.getGrade());
+        grade.setFeedback(request.getFeedback());
+        grade.setGradedAt(java.time.LocalDateTime.now());
+        gradeRepository.save(grade);
+
+        // 6. Recalculate average if grading is complete
+        Submission submission = submissionRepository.findById(submissionId)
+                .orElseThrow(() -> new com.spms.backend.exception.NotFoundException("Submission not found"));
+
+        assignmentRepository
+                .findTopByGroupIdAndStatusOrderByAssignedAtDesc(submission.getGroupId(), "ASSIGNED")
+                .ifPresent(assignment -> {
+                    Committee committee = assignment.getCommittee();
+                    int totalMembers = committee.getAdvisors().size() + committee.getJuryMembers().size();
+                    List<SubmissionGrade> allGrades = gradeRepository.findBySubmissionId(submissionId);
+
+                    if (allGrades.size() >= totalMembers) {
+                        double average = allGrades.stream()
+                                .mapToDouble(SubmissionGrade::getScore)
+                                .average()
+                                .orElse(0.0);
+                        submission.setFinalGrade(average);
+                        submission.setStatus(SubmissionStatus.GRADED);
+                        submissionRepository.save(submission);
+                    }
+                });
+
+        return new SuccessResponse("success", "Grade updated successfully.");
     }
 }

--- a/backend/src/main/java/com/spms/backend/service/SubmissionGradeService.java
+++ b/backend/src/main/java/com/spms/backend/service/SubmissionGradeService.java
@@ -201,15 +201,12 @@ public class SubmissionGradeService {
         }
 
         // 4. D10 Schedule Deadline Check → 403
-        // TODO: [P3-DEADLINE] The schedule table currently lacks a grading_deadline column.
-        //       Once the column is added to the schedule table and Schedule entity,
-        //       uncomment the following block to enforce the grading deadline.
-        // scheduleRepository.findTopByOrderByIdDesc().ifPresent(schedule -> {
-        //     if (schedule.getGradingDeadline() != null
-        //             && java.time.Instant.now().isAfter(schedule.getGradingDeadline())) {
-        //         throw new com.spms.backend.exception.ForbiddenException("Grading deadline has passed (D10).");
-        //     }
-        // });
+        scheduleRepository.findTopByOrderByIdDesc().ifPresent(schedule -> {
+            if (schedule.getGradingDeadline() != null
+                    && java.time.Instant.now().isAfter(schedule.getGradingDeadline())) {
+                throw new com.spms.backend.exception.ForbiddenException("Grading deadline has passed (D10).");
+            }
+        });
 
         // 5. Update the grade fields
         grade.setScore(request.getGrade());

--- a/backend/src/test/java/com/spms/backend/service/SubmissionGradeServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/SubmissionGradeServiceTest.java
@@ -31,6 +31,10 @@ class SubmissionGradeServiceTest {
     private GroupRepository groupRepository;
     @Mock
     private NotificationService notificationService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ScheduleRepository scheduleRepository;
 
     @InjectMocks
     private SubmissionGradeService submissionGradeService;
@@ -92,6 +96,9 @@ class SubmissionGradeServiceTest {
         group.setLeader(leader);
 
         SubmissionGrade grade = new SubmissionGrade();
+        grade.setSubmissionId(submissionId);
+        grade.setProfessorId(professorId);
+        grade.setScore(80.0);
         grade.setId(1L);
         grade.setScore(80.0);
 
@@ -146,6 +153,9 @@ class SubmissionGradeServiceTest {
         assignment.setCommittee(committee);
 
         SubmissionGrade grade = new SubmissionGrade();
+        grade.setSubmissionId(submissionId);
+        grade.setProfessorId(professorId);
+        grade.setScore(80.0);
         grade.setId(1L);
         grade.setScore(80.0);
 
@@ -163,6 +173,159 @@ class SubmissionGradeServiceTest {
         assertFalse(response.getData().getIsGradingComplete());
         assertNull(submission.getFinalGrade());
         verify(notificationService, never()).createSystemAlert(anyLong(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void updateGrade_Success_ReturnsSuccessResponse() {
+        // Arrange
+        Long submissionId = 1L;
+        Long gradeId = 100L;
+        Long professorId = 5L;
+        GradeSubmissionRequest request = new GradeSubmissionRequest();
+        request.setGrade(95.0);
+        request.setFeedback("Updated feedback");
+
+        SubmissionGrade existingGrade = new SubmissionGrade();
+        existingGrade.setId(gradeId);
+        existingGrade.setSubmissionId(submissionId);
+        existingGrade.setProfessorId(professorId);
+        existingGrade.setScore(80.0);
+
+        Submission submission = new Submission();
+        submission.setId(submissionId);
+        submission.setGroupId(10L);
+
+        Committee committee = new Committee();
+        CommitteeAdvisor advisor = new CommitteeAdvisor();
+        User advisorUser = new User();
+        advisorUser.setUserId(professorId);
+        advisor.setAdvisor(advisorUser);
+        committee.setAdvisors(Collections.singletonList(advisor));
+        committee.setJuryMembers(Collections.emptyList());
+
+        GroupCommitteeAssignment assignment = new GroupCommitteeAssignment();
+        assignment.setCommittee(committee);
+
+        when(gradeRepository.findById(gradeId)).thenReturn(Optional.of(existingGrade));
+        when(scheduleRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+        when(gradeRepository.save(any(SubmissionGrade.class))).thenReturn(existingGrade);
+        when(submissionRepository.findById(submissionId)).thenReturn(Optional.of(submission));
+        when(assignmentRepository.findTopByGroupIdAndStatusOrderByAssignedAtDesc(10L, "ASSIGNED"))
+                .thenReturn(Optional.of(assignment));
+        when(gradeRepository.findBySubmissionId(submissionId)).thenReturn(Collections.singletonList(existingGrade));
+
+        // Act
+        com.spms.backend.dto.response.SuccessResponse response =
+                submissionGradeService.updateGrade(submissionId, gradeId, professorId, request);
+
+        // Assert — spec says SuccessResponse {status, message}
+        assertEquals("success", response.status());
+        assertEquals("Grade updated successfully.", response.message());
+        // Verify entity fields were updated
+        assertEquals(95.0, existingGrade.getScore());
+        assertEquals("Updated feedback", existingGrade.getFeedback());
+        verify(gradeRepository).save(existingGrade);
+    }
+
+    @Test
+    void updateGrade_NotOwner_ThrowsForbidden() {
+        // Arrange
+        Long submissionId = 1L;
+        Long gradeId = 100L;
+        Long ownerProfessorId = 5L;
+        Long wrongProfessorId = 6L;
+        GradeSubmissionRequest request = new GradeSubmissionRequest();
+        request.setGrade(95.0);
+
+        SubmissionGrade existingGrade = new SubmissionGrade();
+        existingGrade.setId(gradeId);
+        existingGrade.setSubmissionId(submissionId);
+        existingGrade.setProfessorId(ownerProfessorId);
+
+        when(gradeRepository.findById(gradeId)).thenReturn(Optional.of(existingGrade));
+
+        // Act & Assert — must be 403
+        assertThrows(com.spms.backend.exception.ForbiddenException.class, () -> 
+            submissionGradeService.updateGrade(submissionId, gradeId, wrongProfessorId, request)
+        );
+        verify(gradeRepository, never()).save(any());
+    }
+
+    @Test
+    void updateGrade_GradeNotFound_ThrowsNotFound() {
+        // Arrange
+        Long submissionId = 1L;
+        Long gradeId = 999L;
+        Long professorId = 5L;
+        GradeSubmissionRequest request = new GradeSubmissionRequest();
+        request.setGrade(85.0);
+
+        when(gradeRepository.findById(gradeId)).thenReturn(Optional.empty());
+
+        // Act & Assert — must be 404
+        assertThrows(com.spms.backend.exception.NotFoundException.class, () ->
+            submissionGradeService.updateGrade(submissionId, gradeId, professorId, request)
+        );
+    }
+
+    @Test
+    void updateGrade_GradeBelongsToDifferentSubmission_ThrowsNotFound() {
+        // Arrange
+        Long submissionId = 1L;
+        Long differentSubmissionId = 99L;
+        Long gradeId = 100L;
+        Long professorId = 5L;
+        GradeSubmissionRequest request = new GradeSubmissionRequest();
+        request.setGrade(85.0);
+
+        SubmissionGrade existingGrade = new SubmissionGrade();
+        existingGrade.setId(gradeId);
+        existingGrade.setSubmissionId(differentSubmissionId); // belongs to another submission
+        existingGrade.setProfessorId(professorId);
+
+        when(gradeRepository.findById(gradeId)).thenReturn(Optional.of(existingGrade));
+
+        // Act & Assert — must be 404 (grade not found for this submission)
+        assertThrows(com.spms.backend.exception.NotFoundException.class, () ->
+            submissionGradeService.updateGrade(submissionId, gradeId, professorId, request)
+        );
+        verify(gradeRepository, never()).save(any());
+    }
+
+    @Test
+    void updateGrade_UpdatesGradedAtTimestamp() {
+        // Arrange
+        Long submissionId = 1L;
+        Long gradeId = 100L;
+        Long professorId = 5L;
+        GradeSubmissionRequest request = new GradeSubmissionRequest();
+        request.setGrade(90.0);
+
+        java.time.LocalDateTime originalTime = java.time.LocalDateTime.of(2025, 1, 1, 12, 0);
+        SubmissionGrade existingGrade = new SubmissionGrade();
+        existingGrade.setId(gradeId);
+        existingGrade.setSubmissionId(submissionId);
+        existingGrade.setProfessorId(professorId);
+        existingGrade.setScore(80.0);
+        existingGrade.setGradedAt(originalTime);
+
+        Submission submission = new Submission();
+        submission.setId(submissionId);
+        submission.setGroupId(10L);
+
+        when(gradeRepository.findById(gradeId)).thenReturn(Optional.of(existingGrade));
+        when(scheduleRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+        when(gradeRepository.save(any(SubmissionGrade.class))).thenReturn(existingGrade);
+        when(submissionRepository.findById(submissionId)).thenReturn(Optional.of(submission));
+        when(assignmentRepository.findTopByGroupIdAndStatusOrderByAssignedAtDesc(10L, "ASSIGNED"))
+                .thenReturn(Optional.empty());
+
+        // Act
+        submissionGradeService.updateGrade(submissionId, gradeId, professorId, request);
+
+        // Assert — gradedAt should have been refreshed
+        assertNotEquals(originalTime, existingGrade.getGradedAt());
+        assertNotNull(existingGrade.getGradedAt());
     }
 }
 


### PR DESCRIPTION
Summary
This PR implements the Update Own Grade API for Process 3, allowing committee members to update only the grades they previously submitted while strictly adhering to the API spec return types and D10 deadline enforcements.

Changes
- Updated `SubmissionController` with:
  - `PUT /api/v1/submissions/{submissionId}/grades/{gradeId}`
  - Explicit authorization via `@RequestAttribute("jwt_userId")`
  - Proper exception mapping to HTTP 403 and 404 matching the spec
- Implemented `SubmissionGradeService.updateGrade` with:
  - Ownership check (only the professor who gave the grade can update it)
  - Validation to ensure the grade belongs to the correct submission
  - Auto-recalculation of the final grade and transition to `GRADED` status when all members finish
  - `gradedAt` timestamp update upon modification
  - Enabled D10 Schedule-based grading deadline restriction logic (throws 403 if past deadline)
- Updated `Schedule` entity:
  - Added `gradingDeadline` field to map to the new `grading_deadline` column
- Refactored endpoint to return the spec-compliant `SuccessResponse` DTO instead of leaking internal entity data

Testing
- Updated `SubmissionGradeServiceTest` unit tests:
  - Authorization (ForbiddenException for non-owners)
  - Successful update scenarios and final grade recalculation
  - Timestamp refresh verification
- Unit Test Terminal code:
  ```bash
  cd backend
  mvn test -Dtest=SubmissionGradeServiceTest
