### PR TITLE
fix: prevent duplicate root submissions (#77)

### DIFF
--- a/backend/src/main/java/com/spms/backend/repository/SubmissionRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/SubmissionRepository.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 public interface SubmissionRepository extends JpaRepository<Submission, Long> {
 
     Optional<Submission> findTopByGroupIdAndDeliverableTypeOrderByCreatedAtDesc(Long groupId, DeliverableType type);
+    
+    boolean existsByGroupIdAndDeliverableTypeAndParentSubmissionIdIsNull(Long groupId, DeliverableType deliverableType);
 
     Page<Submission> findByGroupId(Long groupId, Pageable pageable);
 

--- a/backend/src/main/java/com/spms/backend/service/impl/SubmissionServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/SubmissionServiceImpl.java
@@ -85,6 +85,11 @@ public class SubmissionServiceImpl implements SubmissionService {
                 .findTopByGroupIdAndStatusOrderByAssignedAtDesc(groupId, "ASSIGNED")
                 .orElseThrow(() -> new ForbiddenException("Group is not assigned to any committee."));
 
+        // Reject if a root submission of this type already exists for the group
+        if (submissionRepository.existsByGroupIdAndDeliverableTypeAndParentSubmissionIdIsNull(groupId, type)) {
+            throw new BadRequestException("A root submission of type " + type + " already exists for this group.");
+        }
+
         // C-6: TODO(P2-dep): submission deadline check against D11 Schedule needs
         // proposal/SoW/demo deadline columns not yet in Schedule entity — touches P2 boundary.
         // Implement once P2 team adds those columns to the schedule table.


### PR DESCRIPTION
## Summary

This PR implements a backend fix to prevent duplicate root submissions for the same deliverable type in Process 3.
It ensures that a group cannot submit multiple initial Proposals or SoWs due to rapid repeated requests (e.g., double-clicking the submit button), protecting the integrity of the D4 database.

---

## Changes

### Backend Validation

Updated `SubmissionServiceImpl.submit` with:

* Validation to check if a root submission already exists for the given:

  * `groupId`
  * `deliverableType`
* Root submission is identified by `parentSubmissionId IS NULL`
* Throws `BadRequestException` if a duplicate root submission is attempted

### Repository Update

Updated `SubmissionRepository` with:

* `existsByGroupIdAndDeliverableTypeAndParentSubmissionIdIsNull(...)`
* Enables efficient detection of existing root submissions

### Data Integrity

* Prevents multiple initial submissions (version = 1 equivalent)
* Preserves revision flow (submissions with non-null `parentSubmissionId` are unaffected)

---

## Concurrency Consideration

* Service-level validation prevents most duplicate submissions
* Recommended database-level safeguard (manual):

```sql
CREATE UNIQUE INDEX idx_unique_root_submission 
ON deliverables (group_id, deliverable_type) 
WHERE parent_submission_id IS NULL;
```

---

## Testing

### Manual Testing

* Send two rapid POST requests to `/api/v1/submissions`
* First request should succeed
* Second request should return `400 Bad Request`

### Expected Behavior

* Only one root submission per group and deliverable type is allowed
* Revision submissions remain fully functional
