### PR TITLE
feat(P5.15): implement committee management frontend dashboards

### DIFF
--- a/frontend/app/committees/[committeeId]/page.tsx
+++ b/frontend/app/committees/[committeeId]/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import Sidebar from "@/components/Sidebar";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { fetchCommitteeById } from "@/lib/committees-api";
+import { Committee } from "@/lib/committee-types";
+import { showToast } from "@/components/toast/ToastContext";
+
+export default function CommitteeDetailPage() {
+    const params = useParams();
+    const committeeId = Number(params.committeeId);
+
+    const [committee, setCommittee] = useState<Committee | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function loadCommittee() {
+            try {
+                setLoading(true);
+                const data = await fetchCommitteeById(committeeId);
+
+                if (!cancelled) {
+                    setCommittee(data);
+                }
+            } catch (err) {
+                showToast(
+                    err instanceof Error ? err.message : "Failed to load committee.",
+                    "error"
+                );
+            } finally {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            }
+        }
+
+        if (!Number.isNaN(committeeId)) {
+            loadCommittee();
+        }
+
+        return () => {
+            cancelled = true;
+        };
+    }, [committeeId]);
+
+    return (
+        <div className="min-h-screen bg-gray-950 flex">
+            <Sidebar activePage="committees" />
+
+            <main className="flex-1 min-w-0 px-6 py-10 text-white">
+                <div className="mx-auto max-w-5xl space-y-8">
+                    <Link href="/committees" className="text-sm text-blue-400 hover:underline">
+                        ← Back to committees
+                    </Link>
+
+                    {loading ? (
+                        <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-8">
+                            <div className="h-8 w-64 animate-pulse rounded bg-white/10" />
+                            <div className="mt-4 h-4 w-96 animate-pulse rounded bg-white/10" />
+                            <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
+                                {Array.from({ length: 3 }).map((_, index) => (
+                                    <div
+                                        key={index}
+                                        className="h-24 animate-pulse rounded-xl bg-white/5"
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    ) : !committee ? (
+                        <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-8 text-red-200">
+                            Committee not found.
+                        </div>
+                    ) : (
+                        <>
+                            <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-8">
+                                <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                                    <div>
+                                        <h1 className="text-3xl font-bold">
+                                            {committee.committeeName}
+                                        </h1>
+                                        <p className="mt-3 max-w-2xl text-gray-400">
+                                            {committee.description || "No description provided."}
+                                        </p>
+                                    </div>
+
+                                    <span className="rounded-full border border-blue-500/20 bg-blue-500/10 px-4 py-2 text-sm text-blue-300">
+                                        {committee.status}
+                                    </span>
+                                </div>
+
+                                <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-3">
+                                    <div className="rounded-xl border border-white/10 bg-white/5 p-5">
+                                        <p className="text-sm text-gray-400">Advisor Count</p>
+                                        <p className="mt-2 text-2xl font-bold">
+                                            {committee.advisorCount ?? 0}
+                                        </p>
+                                    </div>
+
+                                    <div className="rounded-xl border border-white/10 bg-white/5 p-5">
+                                        <p className="text-sm text-gray-400">Jury Count</p>
+                                        <p className="mt-2 text-2xl font-bold">
+                                            {committee.juryCount ?? 0}
+                                        </p>
+                                    </div>
+
+                                    <div className="rounded-xl border border-white/10 bg-white/5 p-5">
+                                        <p className="text-sm text-gray-400">Group Count</p>
+                                        <p className="mt-2 text-2xl font-bold">
+                                            {committee.groupCount ?? 0}
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-6">
+                                <h2 className="text-xl font-semibold">Committee Details</h2>
+
+                                <div className="mt-5 grid grid-cols-1 gap-4 md:grid-cols-2">
+                                    <Info label="Committee ID" value={String(committee.committeeId)} />
+                                    <Info label="Created By" value={`User #${committee.createdBy}`} />
+                                    <Info
+                                        label="Created At"
+                                        value={
+                                            committee.createdAt
+                                                ? new Date(committee.createdAt).toLocaleString()
+                                                : "-"
+                                        }
+                                    />
+                                    <Info
+                                        label="Updated At"
+                                        value={
+                                            committee.updatedAt
+                                                ? new Date(committee.updatedAt).toLocaleString()
+                                                : "-"
+                                        }
+                                    />
+                                </div>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </main>
+        </div>
+    );
+}
+
+function Info({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+            <p className="text-sm text-gray-500">{label}</p>
+            <p className="mt-1 text-sm font-medium text-white">{value}</p>
+        </div>
+    );
+}

--- a/frontend/app/committees/page.tsx
+++ b/frontend/app/committees/page.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import Sidebar from "@/components/Sidebar";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { fetchCommittees } from "@/lib/committees-api";
+import { Committee } from "@/lib/committee-types";
+import { showToast } from "@/components/toast/ToastContext";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+
+export default function CommitteesPage() {
+    const [committees, setCommittees] = useState<Committee[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const pathname = usePathname();
+
+    const initialStatus = searchParams.get("status") || "ALL";
+    const initialSearch = searchParams.get("search") || "";
+    const initialSort = searchParams.get("sort") || "created_desc";
+    const initialPage = Number(searchParams.get("page") || "1");
+    const initialPageSize = Number(searchParams.get("size") || "10");
+
+    const [statusFilter, setStatusFilter] = useState(initialStatus);
+    const [searchInput, setSearchInput] = useState(initialSearch);
+    const [searchQuery, setSearchQuery] = useState(initialSearch);
+    const [sortOption, setSortOption] = useState(initialSort);
+    const [page, setPage] = useState(initialPage);
+    const [pageSize, setPageSize] = useState(initialPageSize);
+    const [totalPages, setTotalPages] = useState(1);
+
+    function updateUrlParams(updates: Record<string, string | number>) {
+        const params = new URLSearchParams(searchParams.toString());
+
+        Object.entries(updates).forEach(([key, value]) => {
+            if (
+                value === "" ||
+                value === "ALL" ||
+                value === "created_desc" ||
+                value === 1 ||
+                value === 10
+            ) {
+                params.delete(key);
+            } else {
+                params.set(key, String(value));
+            }
+        });
+
+        const query = params.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname);
+    }
+
+    async function loadCommittees(
+        nextPage = page,
+        nextStatus = statusFilter,
+        nextSearch = searchQuery,
+        nextSort = sortOption,
+        nextSize = pageSize
+    ) {
+        setLoading(true);
+
+        try {
+            const response = await fetchCommittees(
+                nextPage - 1,
+                nextSize,
+                nextStatus,
+                nextSearch,
+                nextSort
+            );
+
+            setCommittees(response.content);
+            setTotalPages(response.totalPages);
+        } catch (err) {
+            showToast(
+                err instanceof Error ? err.message : "Failed to load committees.",
+                "error"
+            );
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            setPage(1);
+            setSearchQuery(searchInput);
+            updateUrlParams({ search: searchInput, page: 1 });
+        }, 300);
+
+        return () => clearTimeout(timeout);
+    }, [searchInput]);
+
+    useEffect(() => {
+        loadCommittees(1, statusFilter, searchQuery, sortOption, pageSize);
+    }, [statusFilter, searchQuery, sortOption, pageSize]);
+
+    function handlePageChange(nextPage: number) {
+        if (nextPage < 1 || nextPage > totalPages) return;
+
+        setPage(nextPage);
+        updateUrlParams({ page: nextPage });
+        loadCommittees(nextPage, statusFilter, searchQuery, sortOption, pageSize);
+    }
+
+    return (
+        <div className="min-h-screen bg-gray-950 flex">
+            <Sidebar activePage="committees" />
+
+            <main className="flex-1 min-w-0 px-6 py-10 text-white">
+                <div className="mx-auto max-w-6xl space-y-8">
+                    <div>
+                        <h1 className="text-3xl font-bold">Committees</h1>
+                        <p className="mt-2 text-gray-400">
+                            Browse committees and view their current assignments.
+                        </p>
+                    </div>
+
+                    <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-6">
+                        <div className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
+                            <input
+                                type="text"
+                                placeholder="Search committees..."
+                                value={searchInput}
+                                onChange={(e) => setSearchInput(e.target.value)}
+                                className="rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-sm text-white placeholder:text-gray-500 outline-none focus:border-blue-500"
+                            />
+
+                            <select
+                                value={statusFilter}
+                                onChange={(e) => {
+                                    setPage(1);
+                                    setStatusFilter(e.target.value);
+                                    updateUrlParams({ status: e.target.value, page: 1 });
+                                }}
+                                className="rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-sm text-white outline-none focus:border-blue-500"
+                            >
+                                <option value="ALL">All Statuses</option>
+                                <option value="ACTIVE">ACTIVE</option>
+                                <option value="INACTIVE">INACTIVE</option>
+                                <option value="COMPLETED">COMPLETED</option>
+                                <option value="FORMING">FORMING</option>
+                            </select>
+
+                            <select
+                                value={sortOption}
+                                onChange={(e) => {
+                                    setPage(1);
+                                    setSortOption(e.target.value);
+                                    updateUrlParams({ sort: e.target.value, page: 1 });
+                                }}
+                                className="rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-sm text-white outline-none focus:border-blue-500"
+                            >
+                                <option value="created_desc">Created Date ↓</option>
+                                <option value="created_asc">Created Date ↑</option>
+                                <option value="name_asc">Name A-Z</option>
+                                <option value="name_desc">Name Z-A</option>
+                            </select>
+
+                            <select
+                                value={pageSize}
+                                onChange={(e) => {
+                                    const nextSize = Number(e.target.value);
+                                    setPage(1);
+                                    setPageSize(nextSize);
+                                    updateUrlParams({ size: nextSize, page: 1 });
+                                }}
+                                className="rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-sm text-white outline-none focus:border-blue-500"
+                            >
+                                <option value={10}>10 / page</option>
+                                <option value={20}>20 / page</option>
+                                <option value={50}>50 / page</option>
+                            </select>
+                        </div>
+
+                        {loading ? (
+                            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                {Array.from({ length: 6 }).map((_, index) => (
+                                    <div
+                                        key={index}
+                                        className="h-44 animate-pulse rounded-2xl border border-white/10 bg-white/5"
+                                    />
+                                ))}
+                            </div>
+                        ) : committees.length === 0 ? (
+                            <div className="rounded-2xl border border-dashed border-white/10 bg-white/5 px-6 py-16 text-center">
+                                <p className="text-gray-400">
+                                    No committees found. Try adjusting your filters.
+                                </p>
+                            </div>
+                        ) : (
+                            <>
+                                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                    {committees.map((committee) => (
+                                        <Link
+                                            key={committee.committeeId}
+                                            href={`/committees/${committee.committeeId}`}
+                                        >
+                                            <div className="h-full cursor-pointer rounded-2xl border border-white/10 bg-gray-950 p-5 transition hover:border-blue-500/40 hover:bg-white/5">
+                                                <div className="flex items-start justify-between gap-3">
+                                                    <div>
+                                                        <h3 className="font-semibold text-white">
+                                                            {committee.committeeName}
+                                                        </h3>
+                                                        <p className="mt-1 text-sm text-gray-400">
+                                                            {committee.description || "No description"}
+                                                        </p>
+                                                    </div>
+
+                                                    <span className="rounded-full border border-blue-500/20 bg-blue-500/10 px-3 py-1 text-xs text-blue-300">
+                                                        {committee.status}
+                                                    </span>
+                                                </div>
+
+                                                <div className="mt-4 grid grid-cols-3 gap-2 text-center text-xs text-gray-400">
+                                                    <div className="rounded-lg bg-white/5 p-2">
+                                                        <p className="text-white">
+                                                            {committee.advisorCount ?? 0}
+                                                        </p>
+                                                        Advisors
+                                                    </div>
+
+                                                    <div className="rounded-lg bg-white/5 p-2">
+                                                        <p className="text-white">
+                                                            {committee.juryCount ?? 0}
+                                                        </p>
+                                                        Jury
+                                                    </div>
+
+                                                    <div className="rounded-lg bg-white/5 p-2">
+                                                        <p className="text-white">
+                                                            {committee.groupCount ?? 0}
+                                                        </p>
+                                                        Groups
+                                                    </div>
+                                                </div>
+
+                                            </div>
+                                        </Link>
+                                    ))}
+                                </div>
+
+                                <div className="mt-8 flex items-center justify-center gap-3">
+                                    <button
+                                        onClick={() => handlePageChange(page - 1)}
+                                        disabled={page <= 1}
+                                        className="rounded-xl border border-white/10 bg-gray-900 px-4 py-2 text-sm text-gray-300 transition-colors disabled:cursor-not-allowed disabled:opacity-40 hover:bg-white/5"
+                                    >
+                                        Previous
+                                    </button>
+
+                                    <span className="text-sm text-gray-400">
+                                        Page <span className="text-white">{page}</span> /{" "}
+                                        <span className="text-white">{totalPages}</span>
+                                    </span>
+
+                                    <button
+                                        onClick={() => handlePageChange(page + 1)}
+                                        disabled={page >= totalPages}
+                                        className="rounded-xl border border-white/10 bg-gray-900 px-4 py-2 text-sm text-gray-300 transition-colors disabled:cursor-not-allowed disabled:opacity-40 hover:bg-white/5"
+                                    >
+                                        Next
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/app/coordinator/committees/page.tsx
+++ b/frontend/app/coordinator/committees/page.tsx
@@ -1,0 +1,402 @@
+"use client";
+
+import Sidebar from "@/components/Sidebar";
+import CommitteeForm from "@/components/committee/CommitteeForm";
+import { showToast } from "@/components/toast/ToastContext";
+import {
+    createCommittee,
+    deleteCommittee,
+    fetchCoordinatorCommittees,
+    updateCommittee,
+} from "@/lib/committees-api";
+import { Committee, CommitteeFormValues } from "@/lib/committee-types";
+import { getUser } from "@/lib/auth";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+
+export default function CoordinatorCommitteesPage() {
+    const [committees, setCommittees] = useState<Committee[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [showCreate, setShowCreate] = useState(false);
+    const [editingCommittee, setEditingCommittee] = useState<Committee | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+    const [apiError, setApiError] = useState("");
+    const [totalPages, setTotalPages] = useState(1);
+
+    function updateUrlParams(updates: Record<string, string | number>) {
+        const params = new URLSearchParams(searchParams.toString());
+
+        Object.entries(updates).forEach(([key, value]) => {
+            if (
+                value === "" ||
+                value === "ALL" ||
+                value === "created_desc" ||
+                value === 1 ||
+                value === 10
+            ) {
+                params.delete(key);
+            } else {
+                params.set(key, String(value));
+            }
+        });
+
+        const query = params.toString();
+        router.replace(query ? `${pathname}?${query}` : pathname);
+    }
+
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const pathname = usePathname();
+
+    const initialStatus = searchParams.get("status") || "ALL";
+    const initialSearch = searchParams.get("search") || "";
+    const initialSort = searchParams.get("sort") || "created_desc";
+    const initialPage = Number(searchParams.get("page") || "1");
+    const initialPageSize = Number(searchParams.get("size") || "10");
+
+    const [statusFilter, setStatusFilter] = useState(initialStatus);
+    const [searchInput, setSearchInput] = useState(initialSearch);
+    const [searchQuery, setSearchQuery] = useState(initialSearch);
+    const [sortOption, setSortOption] = useState(initialSort);
+    const [page, setPage] = useState(initialPage);
+    const [pageSize, setPageSize] = useState(initialPageSize);
+
+    const currentUser = getUser();
+    const coordinatorId = currentUser?.userId ?? 1;
+
+    async function loadCommittees(
+        nextPage = page,
+        nextStatus = statusFilter,
+        nextSearch = searchQuery,
+        nextSort = sortOption,
+        nextSize = pageSize
+    ) {
+        setLoading(true);
+        try {
+            const response = await fetchCoordinatorCommittees(
+                coordinatorId,
+                nextPage - 1,
+                nextSize,
+                nextStatus,
+                nextSearch,
+                nextSort
+            );
+
+            setCommittees(response.content);
+            setTotalPages(response.totalPages);
+        } catch (err) {
+            showToast(
+                err instanceof Error ? err.message : "Failed to load committees.",
+                "error"
+            );
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        loadCommittees(1, statusFilter, searchQuery, sortOption, pageSize);
+    }, [statusFilter, searchQuery, sortOption, pageSize]);
+
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            setPage(1);
+            setSearchQuery(searchInput);
+            updateUrlParams({ search: searchInput, page: 1 });
+        }, 300);
+
+        return () => clearTimeout(timeout);
+    }, [searchInput]);
+
+    async function handleCreate(values: CommitteeFormValues) {
+        setSubmitting(true);
+        setApiError("");
+
+        try {
+            await createCommittee(values);
+            showToast("Committee created successfully.", "success");
+            setShowCreate(false);
+            await loadCommittees(1, statusFilter, searchQuery, sortOption, pageSize);
+        } catch (err) {
+            const message =
+                err instanceof Error ? err.message : "Failed to create committee.";
+            setApiError(message);
+            showToast(message, "error");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    async function handleUpdate(values: CommitteeFormValues) {
+        if (!editingCommittee) return;
+
+        setSubmitting(true);
+        setApiError("");
+
+        try {
+            await updateCommittee(editingCommittee.committeeId, values);
+            showToast("Committee updated successfully.", "success");
+            setEditingCommittee(null);
+            await loadCommittees(page, statusFilter, searchQuery, sortOption, pageSize);
+        } catch (err) {
+            const message =
+                err instanceof Error ? err.message : "Failed to update committee.";
+            setApiError(message);
+            showToast(message, "error");
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    async function handleDelete(committeeId: number) {
+        const confirmed = window.confirm(
+            "Are you sure you want to delete this committee?"
+        );
+
+        if (!confirmed) return;
+
+        try {
+            await deleteCommittee(committeeId);
+            showToast("Committee deleted successfully.", "success");
+            await loadCommittees(page, statusFilter, searchQuery, sortOption, pageSize);
+        } catch (err) {
+            showToast(
+                err instanceof Error ? err.message : "Failed to delete committee.",
+                "error"
+            );
+        }
+    }
+
+    function handlePageChange(nextPage: number) {
+        if (nextPage < 1 || nextPage > totalPages) return;
+
+        setPage(nextPage);
+        updateUrlParams({ page: nextPage });
+        loadCommittees(nextPage, statusFilter, searchQuery, sortOption, pageSize);
+    }
+
+    return (
+        <div className="min-h-screen bg-gray-950 flex">
+            <Sidebar activePage="committees" />
+
+            <main className="flex-1 min-w-0 px-6 py-10 text-white">
+                <div className="mx-auto max-w-6xl space-y-8">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                        <div>
+                            <h1 className="text-3xl font-bold">Committee Management</h1>
+                            <p className="mt-2 text-gray-400">
+                                Create, edit, delete, and review committees.
+                            </p>
+                        </div>
+
+                        <button
+                            onClick={() => {
+                                setShowCreate((prev) => !prev);
+                                setEditingCommittee(null);
+                                setApiError("");
+                            }}
+                            className="rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-500"
+                        >
+                            {showCreate ? "Close" : "+ Create Committee"}
+                        </button>
+                    </div>
+
+                    {showCreate && (
+                        <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-6">
+                            <h2 className="mb-4 text-xl font-semibold">Create Committee</h2>
+                            <CommitteeForm
+                                onSubmit={handleCreate}
+                                isSubmitting={submitting}
+                                apiError={apiError}
+                            />
+                        </div>
+                    )}
+
+                    {editingCommittee && (
+                        <div className="rounded-2xl border border-yellow-500/20 bg-yellow-500/5 p-6">
+                            <h2 className="mb-4 text-xl font-semibold">Edit Committee</h2>
+                            <CommitteeForm
+                                initialValues={{
+                                    committeeName: editingCommittee.committeeName,
+                                    description: editingCommittee.description ?? "",
+                                    status: editingCommittee.status,
+                                }}
+                                onSubmit={handleUpdate}
+                                isSubmitting={submitting}
+                                apiError={apiError}
+                                submitLabel="Update"
+                            />
+                        </div>
+                    )}
+
+                    <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-6">
+                        <div className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-4">
+                            <input
+                                type="text"
+                                placeholder="Search committees..."
+                                value={searchInput}
+                                onChange={(e) => setSearchInput(e.target.value)}
+                                className="rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-sm text-white placeholder:text-gray-500 outline-none focus:border-blue-500"
+                            />
+
+                            <select
+                                value={statusFilter}
+                                onChange={(e) => {
+                                    setPage(1);
+                                    setStatusFilter(e.target.value);
+                                    updateUrlParams({ status: e.target.value, page: 1 });
+                                }}
+                                className="rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-sm text-white outline-none focus:border-blue-500"
+                            >
+                                <option value="ALL">All Statuses</option>
+                                <option value="ACTIVE">ACTIVE</option>
+                                <option value="INACTIVE">INACTIVE</option>
+                                <option value="COMPLETED">COMPLETED</option>
+                                <option value="FORMING">FORMING</option>
+                            </select>
+
+                            <select
+                                value={sortOption}
+                                onChange={(e) => {
+                                    setPage(1);
+                                    setSortOption(e.target.value);
+                                    updateUrlParams({ sort: e.target.value, page: 1 });
+                                }}
+                                className="rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-sm text-white outline-none focus:border-blue-500"
+                            >
+                                <option value="created_desc">Created Date ↓</option>
+                                <option value="created_asc">Created Date ↑</option>
+                                <option value="name_asc">Name A-Z</option>
+                                <option value="name_desc">Name Z-A</option>
+                            </select>
+
+                            <select
+                                value={pageSize}
+                                onChange={(e) => {
+                                    const nextSize = Number(e.target.value);
+                                    setPage(1);
+                                    setPageSize(nextSize);
+                                    updateUrlParams({ size: nextSize, page: 1 });
+                                }}
+                                className="rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-sm text-white outline-none focus:border-blue-500"
+                            >
+                                <option value={10}>10 / page</option>
+                                <option value={20}>20 / page</option>
+                                <option value={50}>50 / page</option>
+                            </select>
+                        </div>
+                        {loading ? (
+                            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+                                {Array.from({ length: 6 }).map((_, index) => (
+                                    <div
+                                        key={index}
+                                        className="h-44 animate-pulse rounded-2xl border border-white/10 bg-white/5"
+                                    />
+                                ))}
+                            </div>
+                        ) : committees.length === 0 ? (
+                            <div className="rounded-2xl border border-dashed border-white/10 bg-white/5 px-6 py-16 text-center">
+                                <p className="text-gray-400">
+                                    No committees found. Try adjusting your filters.
+                                </p>
+                            </div>
+                        ) : (
+                            <>
+
+
+                                <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+
+                                    {committees.map((committee) => (
+                                        <div
+                                            key={committee.committeeId}
+                                            className="rounded-2xl border border-white/10 bg-gray-950 p-5"
+                                        >
+                                            <div className="flex items-start justify-between gap-3">
+                                                <div>
+                                                    <h3 className="font-semibold text-white">
+                                                        {committee.committeeName}
+                                                    </h3>
+                                                    <p className="mt-1 text-sm text-gray-400">
+                                                        {committee.description || "No description"}
+                                                    </p>
+                                                </div>
+
+                                                <span className="rounded-full border border-blue-500/20 bg-blue-500/10 px-3 py-1 text-xs text-blue-300">
+                                                    {committee.status}
+                                                </span>
+                                            </div>
+
+                                            <div className="mt-4 grid grid-cols-3 gap-2 text-center text-xs text-gray-400">
+                                                <div className="rounded-lg bg-white/5 p-2">
+                                                    <p className="text-white">{committee.advisorCount ?? 0}</p>
+                                                    Advisors
+                                                </div>
+                                                <div className="rounded-lg bg-white/5 p-2">
+                                                    <p className="text-white">{committee.juryCount ?? 0}</p>
+                                                    Jury
+                                                </div>
+                                                <div className="rounded-lg bg-white/5 p-2">
+                                                    <p className="text-white">{committee.groupCount ?? 0}</p>
+                                                    Groups
+                                                </div>
+                                            </div>
+
+                                            <div className="mt-5 grid grid-cols-3 gap-2">
+                                                <button
+                                                    onClick={() => {
+                                                        setEditingCommittee(committee);
+                                                        setShowCreate(false);
+                                                        setApiError("");
+                                                    }}
+                                                    className="rounded-xl bg-white/10 px-4 py-2 text-sm text-white hover:bg-white/15"
+                                                >
+                                                    Edit
+                                                </button>
+
+                                                <button
+                                                    onClick={() => handleDelete(committee.committeeId)}
+                                                    className="rounded-xl bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-500"
+                                                >
+                                                    Delete
+                                                </button>
+
+                                                <a
+                                                    href={`/committees/${committee.committeeId}`}
+                                                    className="rounded-xl bg-blue-600 px-4 py-2 text-center text-sm text-white hover:bg-blue-500"
+                                                >
+                                                    View
+                                                </a>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                                <div className="mt-8 flex items-center justify-center gap-3">
+                                    <button
+                                        onClick={() => handlePageChange(page - 1)}
+                                        disabled={page <= 1}
+                                        className="rounded-xl border border-white/10 bg-gray-900 px-4 py-2 text-sm text-gray-300 transition-colors disabled:cursor-not-allowed disabled:opacity-40 hover:bg-white/5"
+                                    >
+                                        Previous
+                                    </button>
+
+                                    <span className="text-sm text-gray-400">
+                                        Page <span className="text-white">{page}</span> /{" "}
+                                        <span className="text-white">{totalPages}</span>
+                                    </span>
+
+                                    <button
+                                        onClick={() => handlePageChange(page + 1)}
+                                        disabled={page >= totalPages}
+                                        className="rounded-xl border border-white/10 bg-gray-900 px-4 py-2 text-sm text-gray-300 transition-colors disabled:cursor-not-allowed disabled:opacity-40 hover:bg-white/5"
+                                    >
+                                        Next
+                                    </button>
+                                </div>
+                            </>
+                        )}
+                    </div>
+                </div>
+            </main>
+        </div>
+    );
+}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -94,6 +94,13 @@ export default function Sidebar({ activePage }: { activePage: string }) {
               }
               badge
             />
+            <NavItem
+              label="Committees"
+              active={activePage === "committees"}
+              href="/committees"
+              icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" /></svg>}
+
+            />
           </>
         )}
         {user.role === "coordinator" && (
@@ -181,18 +188,29 @@ export default function Sidebar({ activePage }: { activePage: string }) {
               href="/professor/my-advisees"
               icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197" /></svg>}
             />
+            <NavItem
+              label="Committees"
+              active={activePage === "committees"}
+              href="/committees"
+              icon={
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+                    d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18" />
+                </svg>
+              }
+            />
           </>
         )}
 
         {(user.role === "coordinator" || user.role === "professor") && (
           <>
-             <p className="text-xs font-medium text-gray-600 px-3 mt-4 mb-2 uppercase tracking-widest">Personnel</p>
-             <NavItem
-               label="Register Personnel"
-               active={activePage === "register"}
-               href="/admin/register"
-               icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M19 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0z" /></svg>}
-             />
+            <p className="text-xs font-medium text-gray-600 px-3 mt-4 mb-2 uppercase tracking-widest">Personnel</p>
+            <NavItem
+              label="Register Personnel"
+              active={activePage === "register"}
+              href="/admin/register"
+              icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M19 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0z" /></svg>}
+            />
           </>
         )}
       </nav>

--- a/frontend/components/committee/AssignmentForm.tsx
+++ b/frontend/components/committee/AssignmentForm.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+type Professor = {
+    id: number;
+    name: string;
+};
+
+type Props = {
+    professors: Professor[];
+    onSubmit: (professorId: number) => void;
+    type: "ADVISOR" | "JURY";
+    error?: string;
+};
+
+export default function AssignmentForm({
+    professors,
+    onSubmit,
+    type,
+    error,
+}: Props) {
+    let selectedId = "";
+
+    function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+
+        const id = Number(selectedId);
+        if (!id) return;
+
+        onSubmit(id);
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            {error && (
+                <div
+                    role="alert"
+                    className="text-red-300 bg-red-500/10 border border-red-500/20 px-4 py-2 rounded-xl text-sm"
+                >
+                    {error}
+                </div>
+            )}
+
+            <div>
+                <label className="block text-sm text-gray-300 mb-2">
+                    Select Professor
+                </label>
+
+                <select
+                    onChange={(e) => (selectedId = e.target.value)}
+                    className="w-full rounded-xl bg-gray-900 border border-white/10 px-4 py-3 text-white"
+                >
+                    <option value="">Select...</option>
+                    {professors.map((p) => (
+                        <option key={p.id} value={p.id}>
+                            {p.name}
+                        </option>
+                    ))}
+                </select>
+            </div>
+
+            <button
+                type="submit"
+                className="rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-500"
+            >
+                Assign
+            </button>
+        </form>
+    );
+}

--- a/frontend/components/committee/CommitteeForm.tsx
+++ b/frontend/components/committee/CommitteeForm.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { CommitteeFormValues, CommitteeStatus } from "@/lib/committee-types";
+
+type Props = {
+    initialValues?: Partial<CommitteeFormValues>;
+    onSubmit: (values: CommitteeFormValues) => Promise<void> | void;
+    isSubmitting?: boolean;
+    apiError?: string;
+    submitLabel?: string;
+};
+
+export default function CommitteeForm({
+    initialValues,
+    onSubmit,
+    isSubmitting = false,
+    apiError = "",
+    submitLabel = "Submit",
+}: Props) {
+    const [committeeName, setCommitteeName] = useState(
+        initialValues?.committeeName ?? ""
+    );
+    const [description, setDescription] = useState(
+        initialValues?.description ?? ""
+    );
+    const [status, setStatus] = useState<CommitteeStatus>(
+        initialValues?.status ?? "FORMING"
+    );
+    const [validationError, setValidationError] = useState("");
+
+    async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+        e.preventDefault();
+        setValidationError("");
+
+        const trimmedName = committeeName.trim();
+
+        if (!trimmedName) {
+            setValidationError("Committee name is required.");
+            return;
+        }
+
+        if (trimmedName.length < 3 || trimmedName.length > 100) {
+            setValidationError("Committee name must be between 3 and 100 characters.");
+            return;
+        }
+
+        await onSubmit({
+            committeeName: trimmedName,
+            description: description.trim() || undefined,
+            status,
+        });
+    }
+
+    const errorMessage = validationError || apiError;
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-4">
+            {errorMessage && (
+                <div
+                    role="alert"
+                    className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300"
+                >
+                    {errorMessage}
+                </div>
+            )}
+
+            <div>
+                <label
+                    htmlFor="committeeName"
+                    className="mb-2 block text-sm font-medium text-gray-300"
+                >
+                    Committee Name
+                </label>
+                <input
+                    id="committeeName"
+                    type="text"
+                    value={committeeName}
+                    onChange={(e) => setCommitteeName(e.target.value)}
+                    disabled={isSubmitting}
+                    className="w-full rounded-xl border border-white/10 bg-gray-900 px-4 py-3 text-sm text-white placeholder:text-gray-500 outline-none focus:border-blue-500"
+                    placeholder="Senior Project Jury"
+                />
+            </div>
+
+            <div>
+                <label
+                    htmlFor="committeeDescription"
+                    className="mb-2 block text-sm font-medium text-gray-300"
+                >
+                    Description
+                </label>
+                <textarea
+                    id="committeeDescription"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    disabled={isSubmitting}
+                    rows={3}
+                    className="w-full rounded-xl border border-white/10 bg-gray-900 px-4 py-3 text-sm text-white placeholder:text-gray-500 outline-none focus:border-blue-500"
+                    placeholder="Optional description"
+                />
+            </div>
+
+            <div>
+                <label
+                    htmlFor="committeeStatus"
+                    className="mb-2 block text-sm font-medium text-gray-300"
+                >
+                    Status
+                </label>
+                <select
+                    id="committeeStatus"
+                    value={status}
+                    onChange={(e) => setStatus(e.target.value as CommitteeStatus)}
+                    disabled={isSubmitting}
+                    className="w-full rounded-xl border border-white/10 bg-gray-900 px-4 py-3 text-sm text-white outline-none focus:border-blue-500"
+                >
+                    <option value="FORMING">FORMING</option>
+                    <option value="ACTIVE">ACTIVE</option>
+                    <option value="INACTIVE">INACTIVE</option>
+                    <option value="COMPLETED">COMPLETED</option>
+                </select>
+            </div>
+
+            <button
+                type="submit"
+                disabled={isSubmitting}
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-5 py-3 text-sm font-semibold text-white hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+                {isSubmitting && (
+                    <span
+                        data-testid="loading-spinner"
+                        className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
+                    />
+                )}
+                {submitLabel}
+            </button>
+        </form>
+    );
+}

--- a/frontend/components/committee/CommitteeList.tsx
+++ b/frontend/components/committee/CommitteeList.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Committee } from "@/lib/committee-types";
+
+type Props = {
+    committees: Committee[];
+    onFilterChange?: (status: string) => void;
+    onPageChange?: (page: number) => void;
+    totalPages?: number;
+    currentPage?: number;
+};
+
+export default function CommitteeList({
+    committees,
+    onFilterChange,
+    onPageChange,
+    totalPages = 1,
+    currentPage = 1,
+}: Props) {
+    return (
+        <div className="space-y-4">
+            {/* FILTER */}
+            <div>
+                <label className="text-sm text-gray-300 block mb-2">
+                    Status Filter
+                </label>
+                <select
+                    onChange={(e) => onFilterChange?.(e.target.value)}
+                    className="rounded-xl bg-gray-900 border border-white/10 px-4 py-2 text-white"
+                >
+                    <option value="ALL">All</option>
+                    <option value="ACTIVE">ACTIVE</option>
+                    <option value="FORMING">FORMING</option>
+                    <option value="INACTIVE">INACTIVE</option>
+                    <option value="COMPLETED">COMPLETED</option>
+                </select>
+            </div>
+
+            {/* LIST */}
+            <div className="space-y-2">
+                {committees.map((c) => (
+                    <div
+                        key={c.committeeId}
+                        className="p-4 rounded-xl bg-white/5 border border-white/10"
+                    >
+                        <p className="text-white font-medium">{c.committeeName}</p>
+                        <p className="text-sm text-gray-400">{c.status}</p>
+                    </div>
+                ))}
+
+                {committees.length === 0 && (
+                    <p className="text-gray-500 text-sm">No committees found.</p>
+                )}
+            </div>
+
+            {/* PAGINATION */}
+            <div className="flex gap-2">
+                <button
+                    onClick={() => onPageChange?.(currentPage - 1)}
+                    disabled={currentPage <= 1}
+                    className="px-3 py-2 rounded-lg bg-white/5 text-white disabled:opacity-40"
+                >
+                    Prev
+                </button>
+
+                <button
+                    onClick={() => onPageChange?.(currentPage + 1)}
+                    disabled={currentPage >= totalPages}
+                    className="px-3 py-2 rounded-lg bg-white/5 text-white disabled:opacity-40"
+                >
+                    Next
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/lib/committee-types.ts
+++ b/frontend/lib/committee-types.ts
@@ -1,0 +1,26 @@
+export type CommitteeStatus = "FORMING" | "ACTIVE" | "INACTIVE" | "COMPLETED";
+
+export type Committee = {
+    committeeId: number;
+    committeeName: string;
+    description?: string | null;
+    status: CommitteeStatus;
+    createdBy: number;
+    advisorCount?: number;
+    juryCount?: number;
+    groupCount?: number;
+    createdAt?: string;
+    updatedAt?: string;
+};
+
+export type CommitteeFormValues = {
+    committeeName: string;
+    description?: string;
+    status: CommitteeStatus;
+};
+
+export type CommitteePageResponse = {
+    content: Committee[];
+    totalPages: number;
+    totalElements: number;
+};

--- a/frontend/lib/committees-api.ts
+++ b/frontend/lib/committees-api.ts
@@ -1,0 +1,267 @@
+import { getToken } from "@/lib/auth";
+import {
+    Committee,
+    CommitteeFormValues,
+    CommitteePageResponse,
+    CommitteeStatus,
+} from "@/lib/committee-types";
+
+const API_BASE =
+    process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080/api/v1";
+
+const USE_MOCK = true;
+
+let mockCommittees: Committee[] = [
+    {
+        committeeId: 1,
+        committeeName: "Senior Project Committee A",
+        description: "Main evaluation committee.",
+        status: "ACTIVE",
+        createdBy: 1,
+        advisorCount: 2,
+        juryCount: 3,
+        groupCount: 5,
+        createdAt: "2026-04-20T10:00:00Z",
+        updatedAt: "2026-04-20T10:00:00Z",
+    },
+    {
+        committeeId: 2,
+        committeeName: "Proposal Review Committee",
+        description: "Reviews proposal submissions.",
+        status: "FORMING",
+        createdBy: 1,
+        advisorCount: 1,
+        juryCount: 2,
+        groupCount: 3,
+        createdAt: "2026-04-22T10:00:00Z",
+        updatedAt: "2026-04-22T10:00:00Z",
+    },
+];
+
+async function parseError(res: Response) {
+    try {
+        const data = await res.json();
+        return data?.message || data?.error || "Request failed.";
+    } catch {
+        return "Request failed.";
+    }
+}
+
+function filterSortPaginate(
+    committees: Committee[],
+    page: number,
+    size: number,
+    status: string,
+    search: string,
+    sort: string
+): CommitteePageResponse {
+    let result = [...committees];
+
+    if (status && status !== "ALL") {
+        result = result.filter((committee) => committee.status === status);
+    }
+
+    if (search.trim()) {
+        const query = search.trim().toLowerCase();
+        result = result.filter((committee) =>
+            committee.committeeName.toLowerCase().includes(query)
+        );
+    }
+
+    result.sort((a, b) => {
+        if (sort === "name_asc") return a.committeeName.localeCompare(b.committeeName);
+        if (sort === "name_desc") return b.committeeName.localeCompare(a.committeeName);
+
+        const aDate = new Date(a.createdAt || "").getTime();
+        const bDate = new Date(b.createdAt || "").getTime();
+
+        if (sort === "created_asc") return aDate - bDate;
+        return bDate - aDate;
+    });
+
+    const totalElements = result.length;
+    const totalPages = Math.max(Math.ceil(totalElements / size), 1);
+    const start = page * size;
+
+    return {
+        content: result.slice(start, start + size),
+        totalPages,
+        totalElements,
+    };
+}
+
+export async function fetchCommittees(
+    page = 0,
+    size = 10,
+    status = "ALL",
+    search = "",
+    sort = "created_desc"
+): Promise<CommitteePageResponse> {
+    if (USE_MOCK) {
+        return filterSortPaginate(mockCommittees, page, size, status, search, sort);
+    }
+
+    const token = getToken();
+    const params = new URLSearchParams({
+        page: String(page),
+        size: String(size),
+        sort,
+    });
+
+    if (status !== "ALL") params.set("status", status);
+    if (search) params.set("search", search);
+
+    const res = await fetch(`${API_BASE}/committees?${params.toString()}`, {
+        headers: { Authorization: `Bearer ${token ?? ""}` },
+        cache: "no-store",
+    });
+
+    if (!res.ok) throw new Error(await parseError(res));
+    return res.json();
+}
+
+export async function fetchCoordinatorCommittees(
+    coordinatorId: number,
+    page = 0,
+    size = 10,
+    status = "ALL",
+    search = "",
+    sort = "created_desc"
+): Promise<CommitteePageResponse> {
+    if (USE_MOCK) {
+        return filterSortPaginate(mockCommittees, page, size, status, search, sort);
+    }
+
+    const token = getToken();
+    const params = new URLSearchParams({
+        page: String(page),
+        size: String(size),
+        sort,
+    });
+
+    if (status !== "ALL") params.set("status", status);
+    if (search) params.set("search", search);
+
+    const res = await fetch(
+        `${API_BASE}/committees/coordinator/${coordinatorId}?${params.toString()}`,
+        {
+            headers: { Authorization: `Bearer ${token ?? ""}` },
+            cache: "no-store",
+        }
+    );
+
+    if (!res.ok) throw new Error(await parseError(res));
+    return res.json();
+}
+
+export async function createCommittee(values: CommitteeFormValues) {
+    if (USE_MOCK) {
+        const nextCommittee: Committee = {
+            committeeId: Date.now(),
+            committeeName: values.committeeName,
+            description: values.description || null,
+            status: values.status,
+            createdBy: 1,
+            advisorCount: 0,
+            juryCount: 0,
+            groupCount: 0,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+        };
+
+        mockCommittees = [nextCommittee, ...mockCommittees];
+        return nextCommittee;
+    }
+
+    const token = getToken();
+    const res = await fetch(`${API_BASE}/committees`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token ?? ""}`,
+        },
+        body: JSON.stringify(values),
+    });
+
+    if (!res.ok) throw new Error(await parseError(res));
+    return res.json();
+}
+
+export async function updateCommittee(
+    committeeId: number,
+    values: CommitteeFormValues
+) {
+    if (USE_MOCK) {
+        mockCommittees = mockCommittees.map((committee) =>
+            committee.committeeId === committeeId
+                ? {
+                    ...committee,
+                    ...values,
+                    updatedAt: new Date().toISOString(),
+                }
+                : committee
+        );
+
+        return mockCommittees.find((committee) => committee.committeeId === committeeId);
+    }
+
+    const token = getToken();
+    const res = await fetch(`${API_BASE}/committees/${committeeId}`, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token ?? ""}`,
+        },
+        body: JSON.stringify(values),
+    });
+
+    if (!res.ok) throw new Error(await parseError(res));
+    return res.json();
+}
+
+export async function deleteCommittee(committeeId: number) {
+    if (USE_MOCK) {
+        mockCommittees = mockCommittees.filter(
+            (committee) => committee.committeeId !== committeeId
+        );
+        return;
+    }
+
+    const token = getToken();
+    const res = await fetch(`${API_BASE}/committees/${committeeId}`, {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token ?? ""}` },
+    });
+
+    if (!res.ok) throw new Error(await parseError(res));
+}
+export async function fetchCommitteeById(
+    committeeId: number
+): Promise<Committee> {
+    if (USE_MOCK) {
+        const committee = mockCommittees.find(
+            (item) => item.committeeId === committeeId
+        );
+
+        if (!committee) {
+            throw new Error("Committee not found.");
+        }
+
+        return committee;
+    }
+
+    const token = getToken();
+
+    const res = await fetch(`${API_BASE}/committees/${committeeId}`, {
+        headers: {
+            Authorization: `Bearer ${token ?? ""}`,
+        },
+        cache: "no-store",
+    });
+
+    if (!res.ok) {
+        throw new Error(await parseError(res));
+    }
+
+    return res.json();
+}


### PR DESCRIPTION
## Summary
This PR implements the frontend for the Committee Management Dashboard (P5.17), including both public-facing and coordinator-specific views.

## Features Implemented
- Public Committees Page (/committees)
  - Displays committees in card layout
  - Navigation to committee detail pages
  - Search, filter (status), sort, and pagination
  - URL query parameter synchronization

- Coordinator Committees Page (/coordinator/committees)
  - View, create, edit, and delete committees
  - Pre-filled edit modal
  - Delete confirmation dialog
  - Quick actions: View Details, Edit, Delete

- UI & UX
  - Consistent pagination design across pages
  - Status badges aligned with global styling
  - Responsive grid layout (desktop/tablet/mobile)
  - Empty state and loading states handled
  - Toast notifications for user feedback

## Notes
- Backend API integration is pending; currently using frontend API layer with mock data fallback.
- URL query params reflect active filters (status, search, sort, pagination).
