### PR TITLE
fix: advisor assignment service test paths updated

### DIFF
--- a/backend/src/test/java/com/spms/backend/service/AdvisorAssignmentServiceImplTest.java
+++ b/backend/src/test/java/com/spms/backend/service/AdvisorAssignmentServiceImplTest.java
@@ -41,11 +41,24 @@ class AdvisorAssignmentServiceImplTest {
     @Mock
     private NotificationService notificationService;
 
+    @Mock
+    private com.spms.backend.repository.CommitteeRepository committeeRepository;
+
+    @Mock
+    private com.spms.backend.repository.UserRepository userRepository;
+
+    @Mock
+    private com.spms.backend.repository.CommitteeAdvisorRepository committeeAdvisorRepository;
+
+    @Mock
+    private CommitteeNotificationService committeeNotificationService;
+
     private AdvisorAssignmentServiceImpl service;
 
     @BeforeEach
     void setUp() {
-        service = new AdvisorAssignmentServiceImpl(groupRepository, auditLogRepository, notificationService);
+        service = new AdvisorAssignmentServiceImpl(groupRepository, auditLogRepository, notificationService,
+                committeeRepository, userRepository, committeeAdvisorRepository, committeeNotificationService);
     }
 
     @Test

--- a/backend/src/test/java/com/spms/backend/service/impl/AdvisorAssignmentServiceImplTest.java
+++ b/backend/src/test/java/com/spms/backend/service/impl/AdvisorAssignmentServiceImplTest.java
@@ -8,7 +8,11 @@ import com.spms.backend.model.GroupStatus;
 import com.spms.backend.model.User;
 import com.spms.backend.repository.AbstractStubJpaRepository;
 import com.spms.backend.repository.AuditLogRepository;
+import com.spms.backend.repository.CommitteeAdvisorRepository;
+import com.spms.backend.repository.CommitteeRepository;
 import com.spms.backend.repository.GroupRepository;
+import com.spms.backend.repository.UserRepository;
+import com.spms.backend.service.CommitteeNotificationService;
 import com.spms.backend.service.NotificationService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,6 +33,10 @@ class AdvisorAssignmentServiceImplTest {
     private StubGroupRepository groupRepository;
     private AuditLogRepository auditLogRepository;
     private NotificationService notificationService;
+    private CommitteeRepository committeeRepository;
+    private UserRepository userRepository;
+    private CommitteeAdvisorRepository committeeAdvisorRepository;
+    private CommitteeNotificationService committeeNotificationService;
 
     private AdvisorAssignmentServiceImpl service;
 
@@ -37,7 +45,12 @@ class AdvisorAssignmentServiceImplTest {
         groupRepository = new StubGroupRepository();
         auditLogRepository = new StubAuditLogRepository();
         notificationService = org.mockito.Mockito.mock(NotificationService.class);
-        service = new AdvisorAssignmentServiceImpl(groupRepository, auditLogRepository, notificationService);
+        committeeRepository = org.mockito.Mockito.mock(CommitteeRepository.class);
+        userRepository = org.mockito.Mockito.mock(UserRepository.class);
+        committeeAdvisorRepository = org.mockito.Mockito.mock(CommitteeAdvisorRepository.class);
+        committeeNotificationService = org.mockito.Mockito.mock(CommitteeNotificationService.class);
+        service = new AdvisorAssignmentServiceImpl(groupRepository, auditLogRepository, notificationService,
+                committeeRepository, userRepository, committeeAdvisorRepository, committeeNotificationService);
     }
 
     @Test


### PR DESCRIPTION
 Test Suite Updates - Constructor Parameter Alignment                                                                                                                              
                                                                                                                                                                                      Summary                                                                                                                                                                                                                                                                                                                                                                 Fixed test compilation failures in AdvisorAssignmentServiceImpl test classes due to constructor signature changes introduced in this PR.                                                                                                                                                                                                                                Changes Made                                                                                                                                                                                                                                                                                                                                                            Files Updated:                                                                                                                                                                    
  - backend/src/test/java/com/spms/backend/service/AdvisorAssignmentServiceImplTest.java
  - backend/src/test/java/com/spms/backend/service/impl/AdvisorAssignmentServiceImplTest.java

  Technical Details

  The AdvisorAssignmentServiceImpl constructor was expanded to include four additional dependencies required for committee jury member assignment functionality:
  - CommitteeRepository
  - UserRepository
  - CommitteeAdvisorRepository
  - CommitteeNotificationService

  Both test classes were using outdated constructor calls with only 3 parameters:
  new AdvisorAssignmentServiceImpl(groupRepository, auditLogRepository, notificationService)

  Test Fixes

  AdvisorAssignmentServiceImplTest.java (Mockito-based tests)
  - Added @Mock annotations for the four new dependencies
  - Updated setUp() method to initialize mocks for new repositories and services
  - Adjusted constructor invocation to pass all 7 required parameters

  AdvisorAssignmentServiceImplTest.java (Stub-based integration tests)
  - Added imports for new repository and service classes
  - Created stub/mock instances for the four new dependencies in setUp()
  - Updated constructor invocation to match the new signature

