### PR TITLE
Backend: JIRA Payload Parser & Metrics Appender (#399)

### DIFF
--- a/backend/src/main/java/com/spms/backend/client/JiraApiClient.java
+++ b/backend/src/main/java/com/spms/backend/client/JiraApiClient.java
@@ -1,5 +1,9 @@
 package com.spms.backend.client;
 
+import com.spms.backend.exception.JiraApiException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -8,8 +12,13 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.List;
+import java.util.Map;
+
 @Component
 public class JiraApiClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(JiraApiClient.class);
 
     private final RestClient restClient;
 
@@ -40,6 +49,38 @@ public class JiraApiClient {
             return true;
         } catch (RestClientException exception) {
             return false;
+        }
+    }
+
+    public Map<String, Object> fetchIssuesBatch(
+            String jiraBaseUrl,
+            String apiKey,
+            List<String> issueKeys,
+            int startAt,
+            int maxResults) {
+
+        String jql = "issueKey in (" + String.join(",", issueKeys) + ")";
+
+        String url = UriComponentsBuilder
+                .fromUriString(jiraBaseUrl.trim())
+                .pathSegment("rest", "api", "2", "search")
+                .queryParam("jql", jql)
+                .queryParam("fields", "summary,assignee,resolution,customfield_10004")
+                .queryParam("startAt", startAt)
+                .queryParam("maxResults", maxResults)
+                .build()
+                .toUriString();
+
+        try {
+            return restClient.get()
+                    .uri(url)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.trim())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .body(new ParameterizedTypeReference<Map<String, Object>>() {});
+        } catch (RestClientException e) {
+            logger.error("JIRA batch fetch failed for keys {}: {}", issueKeys, e.getMessage());
+            throw new JiraApiException("JIRA API returned error: " + e.getMessage());
         }
     }
 }

--- a/backend/src/main/java/com/spms/backend/controller/JiraMetricsController.java
+++ b/backend/src/main/java/com/spms/backend/controller/JiraMetricsController.java
@@ -1,0 +1,36 @@
+package com.spms.backend.controller;
+
+import com.spms.backend.dto.request.JiraCallbackRequest;
+import com.spms.backend.dto.request.JiraIssueDetailsRequest;
+import com.spms.backend.dto.response.JiraCallbackResponse;
+import com.spms.backend.dto.response.JiraIssueDetailsResponse;
+import com.spms.backend.service.JiraMetricsService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/jira-metrics")
+public class JiraMetricsController {
+
+    private final JiraMetricsService jiraMetricsService;
+
+    public JiraMetricsController(JiraMetricsService jiraMetricsService) {
+        this.jiraMetricsService = jiraMetricsService;
+    }
+
+    @PostMapping("/callback")
+    public ResponseEntity<JiraCallbackResponse> handleCallback(
+            @Valid @RequestBody JiraCallbackRequest request) {
+        return ResponseEntity.ok(jiraMetricsService.parseAndCleansePayload(request));
+    }
+
+    @PostMapping("/issue-details")
+    public ResponseEntity<JiraIssueDetailsResponse> getIssueDetails(
+            @Valid @RequestBody JiraIssueDetailsRequest request) {
+        return ResponseEntity.ok(jiraMetricsService.fetchAndMergeIssueDetails(request));
+    }
+}

--- a/backend/src/main/java/com/spms/backend/dto/request/JiraCallbackRequest.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/JiraCallbackRequest.java
@@ -1,0 +1,9 @@
+package com.spms.backend.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+public record JiraCallbackRequest(
+    @NotNull List<Map<String, Object>> issues
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/request/JiraIssueDetailsRequest.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/JiraIssueDetailsRequest.java
@@ -1,0 +1,11 @@
+package com.spms.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record JiraIssueDetailsRequest(
+    @NotBlank String jiraSpaceUrl,
+    @NotBlank String apiKey,
+    @NotNull  List<String> issueKeys
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/JiraCallbackResponse.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/JiraCallbackResponse.java
@@ -1,0 +1,8 @@
+package com.spms.backend.dto.response;
+
+import java.util.List;
+
+public record JiraCallbackResponse(
+    int total,
+    List<JiraCleansedIssue> issues
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/JiraCleansedIssue.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/JiraCleansedIssue.java
@@ -1,0 +1,8 @@
+package com.spms.backend.dto.response;
+
+public record JiraCleansedIssue(
+    String issueKey,
+    String assigneeName,
+    String status,
+    int storyPoints
+) {}

--- a/backend/src/main/java/com/spms/backend/dto/response/JiraIssueDetailsResponse.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/JiraIssueDetailsResponse.java
@@ -1,0 +1,9 @@
+package com.spms.backend.dto.response;
+
+import java.util.List;
+
+public record JiraIssueDetailsResponse(
+    int total,
+    int fetched,
+    List<JiraCleansedIssue> issues
+) {}

--- a/backend/src/main/java/com/spms/backend/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/spms/backend/exception/GlobalExceptionHandler.java
@@ -56,6 +56,12 @@ public class GlobalExceptionHandler {
         return buildResponse(HttpStatus.CONFLICT, exception.getMessage());
     }
 
+    @ExceptionHandler(JiraApiException.class)
+    public ResponseEntity<ErrorResponse> handleJiraApiException(JiraApiException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(new ErrorResponse("JIRA_API_ERROR", exception.getMessage()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException exception) {
         String message = exception.getBindingResult()

--- a/backend/src/main/java/com/spms/backend/exception/JiraApiException.java
+++ b/backend/src/main/java/com/spms/backend/exception/JiraApiException.java
@@ -1,0 +1,10 @@
+package com.spms.backend.exception;
+
+public class JiraApiException extends RuntimeException {
+    public JiraApiException(String message) {
+        super(message);
+    }
+    public JiraApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/spms/backend/service/JiraMetricsService.java
+++ b/backend/src/main/java/com/spms/backend/service/JiraMetricsService.java
@@ -1,0 +1,11 @@
+package com.spms.backend.service;
+
+import com.spms.backend.dto.request.JiraCallbackRequest;
+import com.spms.backend.dto.request.JiraIssueDetailsRequest;
+import com.spms.backend.dto.response.JiraCallbackResponse;
+import com.spms.backend.dto.response.JiraIssueDetailsResponse;
+
+public interface JiraMetricsService {
+    JiraCallbackResponse parseAndCleansePayload(JiraCallbackRequest request);
+    JiraIssueDetailsResponse fetchAndMergeIssueDetails(JiraIssueDetailsRequest request);
+}

--- a/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
@@ -1,0 +1,105 @@
+package com.spms.backend.service.impl;
+
+import com.spms.backend.client.JiraApiClient;
+import com.spms.backend.dto.request.JiraCallbackRequest;
+import com.spms.backend.dto.request.JiraIssueDetailsRequest;
+import com.spms.backend.dto.response.JiraCallbackResponse;
+import com.spms.backend.dto.response.JiraCleansedIssue;
+import com.spms.backend.dto.response.JiraIssueDetailsResponse;
+import com.spms.backend.exception.JiraApiException;
+import com.spms.backend.service.JiraMetricsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class JiraMetricsServiceImpl implements JiraMetricsService {
+
+    private static final Logger logger = LoggerFactory.getLogger(JiraMetricsServiceImpl.class);
+    private static final int BATCH_SIZE = 100;
+
+    private final JiraApiClient jiraApiClient;
+
+    public JiraMetricsServiceImpl(JiraApiClient jiraApiClient) {
+        this.jiraApiClient = jiraApiClient;
+    }
+
+    @Override
+    public JiraCallbackResponse parseAndCleansePayload(JiraCallbackRequest request) {
+        List<JiraCleansedIssue> cleansed = new ArrayList<>();
+        for (Map<String, Object> raw : request.issues()) {
+            cleansed.add(extractCleansedIssue(raw));
+        }
+        logger.info("Payload cleansed: {} issues processed", cleansed.size());
+        return new JiraCallbackResponse(cleansed.size(), cleansed);
+    }
+
+    @Override
+    public JiraIssueDetailsResponse fetchAndMergeIssueDetails(JiraIssueDetailsRequest request) {
+        List<String> keys = request.issueKeys();
+        List<JiraCleansedIssue> results = new ArrayList<>();
+
+        int startAt = 0;
+        while (startAt < keys.size()) {
+            List<String> batch = keys.subList(startAt, Math.min(startAt + BATCH_SIZE, keys.size()));
+
+            Map<String, Object> response;
+            try {
+                response = jiraApiClient.fetchIssuesBatch(
+                        request.jiraSpaceUrl(), request.apiKey(), batch, 0, BATCH_SIZE);
+            } catch (JiraApiException e) {
+                logger.error("JIRA API error during batch fetch (startAt={}): {}", startAt, e.getMessage());
+                throw e;
+            }
+
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> issueList =
+                    (List<Map<String, Object>>) response.getOrDefault("issues", Collections.emptyList());
+
+            for (Map<String, Object> raw : issueList) {
+                results.add(extractCleansedIssue(raw));
+            }
+
+            startAt += BATCH_SIZE;
+        }
+
+        logger.info("Issue details fetched: {}/{} keys resolved", results.size(), keys.size());
+        return new JiraIssueDetailsResponse(keys.size(), results.size(), results);
+    }
+
+    // fields.assignee.displayName → assigneeName  (test kontratı)
+    // fields.resolution.name     → status         (test kontratı)
+    // fields.customfield_10004   → storyPoints     (test kontratı)
+    private JiraCleansedIssue extractCleansedIssue(Map<String, Object> raw) {
+        String key = (String) raw.getOrDefault("key", "UNKNOWN");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> fields =
+                (Map<String, Object>) raw.getOrDefault("fields", Collections.emptyMap());
+
+        String assigneeName = "Unassigned";
+        Object assigneeObj = fields.get("assignee");
+        if (assigneeObj instanceof Map<?, ?> assigneeMap && assigneeMap.get("displayName") != null) {
+            assigneeName = (String) assigneeMap.get("displayName");
+        }
+
+        String status = "Unresolved";
+        Object resolutionObj = fields.get("resolution");
+        if (resolutionObj instanceof Map<?, ?> resMap && resMap.get("name") != null) {
+            status = (String) resMap.get("name");
+        }
+
+        int storyPoints = 0;
+        Object sp = fields.get("customfield_10004");
+        if (sp instanceof Number num) {
+            storyPoints = num.intValue();
+        }
+
+        return new JiraCleansedIssue(key, assigneeName, status, storyPoints);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Issue #399** — Backend JIRA Payload Parser & Metrics Appender (DFD 6.2).

The raw and complex JSON returned from the JIRA API is cleansed; only the fields relevant to the system (Assignee, Resolution, Story Points) are mapped to internal DTO objects and task details are enriched.

---

## Deliverables

Two new API endpoints:

| Method | Endpoint | Description |
|--------|----------|-------------|
| `POST` | `/api/v1/jira-metrics/callback` | Receives raw JIRA JSON payload, returns array of cleansed objects |
| `POST` | `/api/v1/jira-metrics/issue-details` | Fetches extra details (SP, Assignee) from JIRA for parsed issue keys and merges them |

---

## Files Added

**DTOs**
- `dto/request/JiraCallbackRequest.java` — accepts raw `List<Map<String,Object>>` (variable JIRA fields)
- `dto/request/JiraIssueDetailsRequest.java` — issue key list + JIRA connection info
- `dto/response/JiraCleansedIssue.java` — cleansed issue: `issueKey`, `assigneeName`, `status`, `storyPoints`
- `dto/response/JiraCallbackResponse.java`
- `dto/response/JiraIssueDetailsResponse.java`

**Exception**
- `exception/JiraApiException.java` — thrown on JIRA API errors (5xx), mapped to HTTP 502

**Service**
- `service/JiraMetricsService.java` — interface
- `service/impl/JiraMetricsServiceImpl.java` — implementation with null-safe field extraction and paginated batch fetching (100 issues per request)

**Controller**
- `controller/JiraMetricsController.java`

## Files Modified

- `client/JiraApiClient.java` — added `fetchIssuesBatch()` method using JIRA REST API v2 `/search` with JQL
- `exception/GlobalExceptionHandler.java` — added `JiraApiException` handler → HTTP 502 Bad Gateway

---

## Technical Details

### Field Mapping (Test Contract)

| Raw JIRA Field | DTO Field | Null Default |
|----------------|-----------|--------------|
| `fields.assignee.displayName` | `assigneeName` | `"Unassigned"` |
| `fields.resolution.name` | `status` | `"Unresolved"` |
| `fields.customfield_10004` | `storyPoints` | `0` |
| `key` | `issueKey` | `"UNKNOWN"` |

### Acceptance Criteria Met

- Hundreds of unnecessary JIRA meta-data fields are stripped; only the 3 required fields are mapped
- If Assignee = null or Story Points is not entered, the system does not crash — defaults are assigned (`"Unassigned"` / `0`)
- JIRA 5xx errors are logged and the system performs a safe halt (HTTP 502 returned)
- Pagination: issues are fetched in batches of 100 using cursor logic until all keys are resolved

---

## References

- Closes #399
- Related: Issue #10 (JIRA JQL Connection Engine), Issue #9 (Credentials Decryptor)
- DFD Sub-process: 6.2