### PR TITLE
fix(advisor): enforce one-group-per-advisor rule on approval

### DIFF
--- a/backend/src/main/java/com/spms/backend/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/NotificationRepository.java
@@ -33,6 +33,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     List<Notification> findByGroupIdAndTypeAndStatusAndToUser_UserIdNot(
             Long groupId, NotificationType type, NotificationStatus status, Long excludedUserId);
 
+    List<Notification> findByToUser_UserIdAndTypeAndStatusAndGroupIdNot(
+            Long toUserId, NotificationType type, NotificationStatus status, Long excludedGroupId);
+
     List<Notification> findByTypeOrderByCreatedAtDesc(NotificationType type);
 
     List<Notification> findByGroupIdAndTypeOrderByCreatedAtDesc(Long groupId, NotificationType type);

--- a/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
@@ -530,6 +530,15 @@ public class GroupServiceImpl implements GroupService {
                 .orElseThrow(() -> new NotFoundException("Professor not found."));
 
         if ("approved".equalsIgnoreCase(status)) {
+            if (group.getAdvisor() != null) {
+                throw new com.spms.backend.exception.ConflictException(
+                        "Group already has an assigned advisor. The advisor must release the group first.");
+            }
+            if (groupRepository.countByAdvisor_UserId(professorId) > 0) {
+                throw new com.spms.backend.exception.ConflictException(
+                        "You are already advising another group. Release that group before accepting a new advisee.");
+            }
+
             group.setAdvisor(professor);
             group.setStatus(GroupStatus.ADVISED);
             group.setUpdatedAt(Instant.now());
@@ -561,6 +570,34 @@ public class GroupServiceImpl implements GroupService {
                         "Auto-rejected pending advisor request for professor " + otherReq.getToUser().getUserId() + " ("
                                 + otherReq.getToUser().getFullName() + ") due to approval of a different advisor.");
                 auditLogRepository.save(log);
+            }
+
+            // Spec: "the advisor must release the team first in order them to make another advisee request."
+            List<Notification> otherGroupRequestsToSameProfessor =
+                    notificationRepository.findByToUser_UserIdAndTypeAndStatusAndGroupIdNot(
+                            professorId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING, groupId);
+            for (Notification otherReq : otherGroupRequestsToSameProfessor) {
+                otherReq.setStatus(NotificationStatus.REJECTED);
+                notificationRepository.save(otherReq);
+
+                Notification leaderNotif = new Notification();
+                leaderNotif.setType(NotificationType.SYSTEM_ALERT);
+                leaderNotif.setStatus(NotificationStatus.PENDING);
+                leaderNotif.setMessage("Your advisor request to professor " + professor.getFullName()
+                        + " was automatically rejected because they accepted another group.");
+                leaderNotif.setGroupId(otherReq.getGroupId());
+                leaderNotif.setFromUser(professor);
+                leaderNotif.setToUser(otherReq.getFromUser());
+                notificationRepository.save(leaderNotif);
+
+                AuditLog occupiedLog = new AuditLog();
+                occupiedLog.setActionType(ActionType.ADVISOR_REJECTED);
+                occupiedLog.setUserId(professorId);
+                occupiedLog.setGroupId(otherReq.getGroupId());
+                occupiedLog.setEventDetails(
+                        "Auto-rejected pending advisor request from group " + otherReq.getGroupId()
+                                + " because professor " + professorId + " accepted a different group.");
+                auditLogRepository.save(occupiedLog);
             }
 
             Notification notif = new Notification();
@@ -618,6 +655,10 @@ public class GroupServiceImpl implements GroupService {
             if (group.getAdvisor() != null) {
                 throw new com.spms.backend.exception.ConflictException("Group already has an assigned advisor. The advisor must release the group first.");
             }
+            if (groupRepository.countByAdvisor_UserId(professorId) > 0) {
+                throw new com.spms.backend.exception.ConflictException(
+                        "You are already advising another group. Release that group before accepting a new advisee.");
+            }
             group.setAdvisor(professor);
             group.setStatus(GroupStatus.ADVISED);
             group.setUpdatedAt(Instant.now());
@@ -663,6 +704,36 @@ public class GroupServiceImpl implements GroupService {
                         "Auto-rejected pending advisor request for professor " + otherReq.getToUser().getUserId() + " ("
                                 + otherReq.getToUser().getFullName() + ") due to approval of a different advisor.");
                 auditLogRepository.save(log);
+            }
+
+            // Spec: "the advisor must release the team first in order them to make another advisee request."
+            // Once the professor is matched with this group, all PENDING requests from OTHER groups
+            // to this same professor must be auto-rejected — the professor is now occupied.
+            List<Notification> otherGroupRequestsToSameProfessor =
+                    notificationRepository.findByToUser_UserIdAndTypeAndStatusAndGroupIdNot(
+                            professorId, NotificationType.ADVISOR_REQUEST, NotificationStatus.PENDING, groupId);
+            for (Notification otherReq : otherGroupRequestsToSameProfessor) {
+                otherReq.setStatus(NotificationStatus.REJECTED);
+                notificationRepository.save(otherReq);
+
+                Notification leaderNotif = new Notification();
+                leaderNotif.setType(NotificationType.SYSTEM_ALERT);
+                leaderNotif.setStatus(NotificationStatus.PENDING);
+                leaderNotif.setMessage("Your advisor request to professor " + professor.getFullName()
+                        + " was automatically rejected because they accepted another group.");
+                leaderNotif.setGroupId(otherReq.getGroupId());
+                leaderNotif.setFromUser(professor);
+                leaderNotif.setToUser(otherReq.getFromUser());
+                notificationRepository.save(leaderNotif);
+
+                AuditLog occupiedLog = new AuditLog();
+                occupiedLog.setActionType(ActionType.ADVISOR_REJECTED);
+                occupiedLog.setUserId(professorId);
+                occupiedLog.setGroupId(otherReq.getGroupId());
+                occupiedLog.setEventDetails(
+                        "Auto-rejected pending advisor request from group " + otherReq.getGroupId()
+                                + " because professor " + professorId + " accepted a different group.");
+                auditLogRepository.save(occupiedLog);
             }
 
             Notification notif = new Notification();

--- a/backend/src/test/java/com/spms/api/AdvisorOccupancyApiTest.java
+++ b/backend/src/test/java/com/spms/api/AdvisorOccupancyApiTest.java
@@ -1,0 +1,165 @@
+package com.spms.api;
+
+import com.spms.backend.model.ActionType;
+import com.spms.backend.model.AuditLog;
+import com.spms.backend.model.Group;
+import com.spms.backend.model.GroupStatus;
+import com.spms.backend.model.User;
+import com.spms.backend.model.notification.Notification;
+import com.spms.backend.model.notification.NotificationStatus;
+import com.spms.backend.model.notification.NotificationType;
+import com.spms.backend.repository.AuditLogRepository;
+import com.spms.backend.repository.GroupRepository;
+import com.spms.backend.repository.NotificationRepository;
+import com.spms.backend.repository.UserRepository;
+import com.spms.backend.service.TokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the spec rule:
+ * "An advisor accepted a group and they are matched, the advisor must release
+ *  the team first in order them to make another advisee request."
+ *
+ * Once a professor approves a group, they are occupied — APPROVE on a different
+ * group must be rejected with 409, and any other groups' PENDING requests to that
+ * same professor must be auto-rejected.
+ */
+@DisplayName("Process 4 - Advisor Occupancy Guard and Same-Professor Auto-Reject")
+class AdvisorOccupancyApiTest extends BaseApiTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private AuditLogRepository auditLogRepository;
+
+    @Autowired
+    private TokenService tokenService;
+
+    private User leaderA;
+    private User leaderB;
+    private User professor;
+
+    private Group groupA;
+    private Group groupB;
+
+    private String professorToken;
+
+    @BeforeEach
+    void setupTwoGroupsOneProfessor() {
+        leaderA = TestDataFactory.createStudent(userRepository, "Leader A",
+                TestDataFactory.uniqueStudentId(), TestDataFactory.uniqueGithubUsername());
+        leaderB = TestDataFactory.createStudent(userRepository, "Leader B",
+                TestDataFactory.uniqueStudentId(), TestDataFactory.uniqueGithubUsername());
+
+        professor = TestDataFactory.createProfessor(userRepository, "Occupied Professor",
+                TestDataFactory.uniqueEmail());
+        professorToken = TestDataFactory.mintToken(tokenService, professor);
+
+        groupA = new Group();
+        groupA.setGroupName("Group A " + System.nanoTime());
+        groupA.setLeader(leaderA);
+        groupA.setStatus(GroupStatus.FORMING);
+        groupA = groupRepository.save(groupA);
+
+        groupB = new Group();
+        groupB.setGroupName("Group B " + System.nanoTime());
+        groupB.setLeader(leaderB);
+        groupB.setStatus(GroupStatus.FORMING);
+        groupB = groupRepository.save(groupB);
+    }
+
+    @Test
+    @DisplayName("Approving a request auto-rejects PENDING requests from other groups to the same professor")
+    void approve_autoRejectsParallelRequestsToSameProfessor() {
+        Notification reqA = seedAdvisorRequest(groupA, leaderA, professor);
+        Notification reqB = seedAdvisorRequest(groupB, leaderB, professor);
+
+        approve(reqA.getId()).statusCode(200);
+
+        Notification updatedA = notificationRepository.findById(reqA.getId()).orElseThrow();
+        assertEquals(NotificationStatus.ACCEPTED, updatedA.getStatus(),
+                "Approved request must be ACCEPTED");
+
+        Notification updatedB = notificationRepository.findById(reqB.getId()).orElseThrow();
+        assertEquals(NotificationStatus.REJECTED, updatedB.getStatus(),
+                "Other group's PENDING request to the same professor must be auto-rejected");
+
+        Group persistedB = groupRepository.findById(groupB.getId()).orElseThrow();
+        assertNull(persistedB.getAdvisor(), "Group B must remain unassigned");
+
+        boolean leaderAlertExists = notificationRepository.findAll().stream()
+                .anyMatch(n -> n.getType() == NotificationType.SYSTEM_ALERT
+                        && n.getStatus() == NotificationStatus.PENDING
+                        && groupB.getId().equals(n.getGroupId())
+                        && n.getToUser() != null
+                        && leaderB.getUserId().equals(n.getToUser().getUserId()));
+        assertTrue(leaderAlertExists,
+                "Group B's leader must receive a SYSTEM_ALERT explaining the auto-rejection");
+
+        List<AuditLog> groupBLogs = auditLogRepository.findAll().stream()
+                .filter(log -> groupB.getId().equals(log.getGroupId())
+                        && log.getActionType() == ActionType.ADVISOR_REJECTED)
+                .toList();
+        assertEquals(1, groupBLogs.size(),
+                "Exactly one ADVISOR_REJECTED audit log must be written for group B");
+    }
+
+    @Test
+    @DisplayName("Approving a second group's request returns 409 when the professor already advises another group")
+    void approve_blocksWhenProfessorAlreadyAdvisesAnotherGroup() {
+        Notification reqA = seedAdvisorRequest(groupA, leaderA, professor);
+        approve(reqA.getId()).statusCode(200);
+
+        Notification reqB = seedAdvisorRequest(groupB, leaderB, professor);
+
+        approve(reqB.getId()).statusCode(409);
+
+        Notification persistedB = notificationRepository.findById(reqB.getId()).orElseThrow();
+        assertEquals(NotificationStatus.PENDING, persistedB.getStatus(),
+                "Blocked request must remain PENDING");
+
+        Group groupBPersisted = groupRepository.findById(groupB.getId()).orElseThrow();
+        assertNull(groupBPersisted.getAdvisor(),
+                "Group B must not be assigned to an already-occupied professor");
+    }
+
+    private Notification seedAdvisorRequest(Group group, User leader, User toProfessor) {
+        Notification n = new Notification();
+        n.setType(NotificationType.ADVISOR_REQUEST);
+        n.setStatus(NotificationStatus.PENDING);
+        n.setGroupId(group.getId());
+        n.setFromUser(leader);
+        n.setToUser(toProfessor);
+        return notificationRepository.save(n);
+    }
+
+    private io.restassured.response.ValidatableResponse approve(Long requestId) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("decision", "APPROVE");
+        return given()
+                .header("Authorization", "Bearer " + professorToken)
+                .body(body)
+                .when()
+                .post("/api/v1/advisor-requests/{requestId}/decision", requestId)
+                .then();
+    }
+}

--- a/backend/src/test/java/com/spms/backend/service/AdvisorRequestDetailServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/AdvisorRequestDetailServiceTest.java
@@ -225,6 +225,7 @@ class AdvisorRequestDetailServiceTest {
         @Override public boolean existsByToUser_UserIdAndTypeAndStatusAndMessageContaining(Long toUserId, NotificationType type, com.spms.backend.model.notification.NotificationStatus status, String messageSnippet) { return false; }
         @Override public List<Notification> findByToUser_UserIdAndTypeAndStatus(Long toUserId, NotificationType type, com.spms.backend.model.notification.NotificationStatus status) { return List.of(); }
         @Override public List<Notification> findByGroupIdAndTypeAndStatusAndToUser_UserIdNot(Long groupId, NotificationType type, com.spms.backend.model.notification.NotificationStatus status, Long excludedUserId) { return List.of(); }
+        @Override public List<Notification> findByToUser_UserIdAndTypeAndStatusAndGroupIdNot(Long toUserId, NotificationType type, com.spms.backend.model.notification.NotificationStatus status, Long excludedGroupId) { return List.of(); }
         @Override public List<Notification> findByTypeOrderByCreatedAtDesc(NotificationType type) { return List.of(); }
         @Override public List<Notification> findByGroupIdAndTypeOrderByCreatedAtDesc(Long groupId, NotificationType type) { return List.of(); }
         @Override public List<Notification> findByCommitteeIdOrderByCreatedAtDesc(Long committeeId) { return List.of(); }


### PR DESCRIPTION
## Summary

Enforces the spec rule for advisor assignment:

> "An advisor accepted a group and they are matched, the advisor must release the team first in order them to make another advisee request."

Previously, once a professor approved a group, nothing prevented them from also accepting other parallel requests from different groups. Two callers were affected — `POST /api/v1/advisor-requests/{requestId}/decision` and the legacy `PATCH /api/v1/professors/advisor-requests`. Both are fixed in this PR.

## Changes

### `GroupServiceImpl.processAdvisorRequestDecision` and `handleAdvisorRequestDecision`

- **New occupancy guard.** On `APPROVE`, the service now checks `groupRepository.countByAdvisor_UserId(professorId) > 0`. If true, it throws `ConflictException`, which `GlobalExceptionHandler` maps to `409 Conflict`. The pre-existing per-group guard (`group.getAdvisor() != null`) is kept; the new check covers the per-professor side.
- **Same-professor auto-reject.** After a successful approval, in addition to the existing same-group sibling sweep, the service now also iterates every `PENDING` `ADVISOR_REQUEST` whose `toUser = professorId` and `groupId != current groupId`, marking each as `REJECTED`, writing a `SYSTEM_ALERT` notification to the affected group's leader (so the student sees why their request died), and writing an `ADVISOR_REJECTED` audit log entry.

### `NotificationRepository`

- New derived query: `findByToUser_UserIdAndTypeAndStatusAndGroupIdNot(...)`. Symmetric to the existing `findByGroupIdAndTypeAndStatusAndToUser_UserIdNot`. Spring Data resolves it from the method name — no custom JPQL.

### `AdvisorRequestDetailServiceTest.StubNotificationRepository`

- Adds a stub override for the new repository method (returns `List.of()`); required so the existing service-layer unit test still compiles.

### `AdvisorOccupancyApiTest` (new)

Two integration tests against the live HTTP layer:

1. `approve_autoRejectsParallelRequestsToSameProfessor` — Group A and Group B both have `PENDING` requests to the same professor. The professor approves Group A. Asserts Group B's request is auto-`REJECTED`, Group B remains advisor-less, Group B's leader receives a `SYSTEM_ALERT`, and exactly one `ADVISOR_REJECTED` audit log is written for Group B.
2. `approve_blocksWhenProfessorAlreadyAdvisesAnotherGroup` — The professor approves Group A, then attempts to approve Group B. Asserts the second call returns `409`, Group B's request stays `PENDING`, and Group B has no advisor.

## How to run the tests

From the `backend/` directory:

```bash
# Run the new test class only
mvn -Dtest=AdvisorOccupancyApiTest test

# Run a single scenario
mvn -Dtest=AdvisorOccupancyApiTest#approve_autoRejectsParallelRequestsToSameProfessor test
mvn -Dtest=AdvisorOccupancyApiTest#approve_blocksWhenProfessorAlreadyAdvisesAnotherGroup test

# Run the full advisor-flow regression set alongside the existing auto-reject tests
mvn -Dtest='Advisor*ApiTest' test

# Full backend test suite
mvn test
```

JUnit / Surefire reports land in `backend/target/surefire-reports/`.

## Compatibility notes

- No DB migration. The fix uses an existing repository method (`countByAdvisor_UserId`) and a derived query — no schema change.
- `User.currentAdviseeCount` is left untouched in this PR; with the one-group-per-advisor rule it is effectively a boolean indicator. Tightening or removing that field is out of scope here.
- Frontend is not touched. The new `409` response from the decision endpoints is already a documented conflict status (`GlobalExceptionHandler` already mapped `ConflictException` to `409` for the previous `group.getAdvisor() != null` case), so existing client error handling continues to apply.

## Test plan

- [ ] `mvn -Dtest=AdvisorOccupancyApiTest test` — both new tests pass.
- [ ] `mvn -Dtest=AdvisorApprovalAutoRejectApiTest test` — existing same-group auto-reject suite still passes (no regression).
- [ ] `mvn -Dtest=AdvisorRequestApiTest test` — existing request-creation suite still passes.
- [ ] `mvn -Dtest=AdvisorRequestDetailServiceTest test` — existing unit test compiles and passes after the new stub override.
- [ ] Manual smoke: as a professor who already advises a group, calling `POST /api/v1/advisor-requests/{id}/decision` with `decision=APPROVE` on another group's request returns `409`.