### PR TITLE
fix: prevent late grading modifications (Resolves #78)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/SubmissionController.java
+++ b/backend/src/main/java/com/spms/backend/controller/SubmissionController.java
@@ -202,9 +202,13 @@ public class SubmissionController {
             GradeSubmissionResponse response = gradeService.submitGrade(id, reviewerId, request);
             return new ResponseEntity<>(response, HttpStatus.CREATED);
         } catch (IllegalArgumentException e) {
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<>(new ErrorResponse("Bad Request", e.getMessage()), HttpStatus.BAD_REQUEST);
         } catch (SecurityException e) {
-            return new ResponseEntity<>(e.getMessage(), HttpStatus.FORBIDDEN);
+            return new ResponseEntity<>(new ErrorResponse("Forbidden", e.getMessage()), HttpStatus.FORBIDDEN);
+        } catch (com.spms.backend.exception.ConflictException e) {
+            return new ResponseEntity<>(new ErrorResponse("Conflict", e.getMessage()), HttpStatus.CONFLICT);
+        } catch (com.spms.backend.exception.ForbiddenException e) {
+            return new ResponseEntity<>(new ErrorResponse("Forbidden", e.getMessage()), HttpStatus.FORBIDDEN);
         } catch (Exception e) {
             return new ResponseEntity<>(new ErrorResponse("Internal Server Error", "An error occurred: " + e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/backend/src/main/java/com/spms/backend/service/SubmissionGradeService.java
+++ b/backend/src/main/java/com/spms/backend/service/SubmissionGradeService.java
@@ -120,6 +120,17 @@ public class SubmissionGradeService {
         Submission submission = submissionRepository.findById(submissionId)
                 .orElseThrow(() -> new IllegalStateException("Submission not found"));
 
+        if (submission.getStatus() == SubmissionStatus.GRADED) {
+            throw new com.spms.backend.exception.ConflictException("Submission is already fully graded.");
+        }
+
+        scheduleRepository.findTopByOrderByIdDesc().ifPresent(schedule -> {
+            if (schedule.getGradingDeadline() != null
+                    && java.time.Instant.now().isAfter(schedule.getGradingDeadline())) {
+                throw new com.spms.backend.exception.ForbiddenException("Grading deadline has passed (D10).");
+            }
+        });
+
         if (gradeRepository.existsBySubmissionIdAndProfessorId(submissionId, professorId)) {
             throw new IllegalArgumentException("Professor has already submitted a grade for this submission");
         }

--- a/backend/src/test/java/com/spms/backend/service/SubmissionGradeServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/SubmissionGradeServiceTest.java
@@ -65,6 +65,53 @@ class SubmissionGradeServiceTest {
     }
 
     @Test
+    void submitGrade_AlreadyGraded_ThrowsConflictException() {
+        // Arrange
+        Long submissionId = 1L;
+        Long professorId = 5L;
+        GradeSubmissionRequest request = new GradeSubmissionRequest();
+        request.setGrade(85.0);
+
+        Submission submission = new Submission();
+        submission.setId(submissionId);
+        submission.setStatus(SubmissionStatus.GRADED);
+
+        when(submissionRepository.findById(submissionId)).thenReturn(Optional.of(submission));
+
+        // Act & Assert
+        com.spms.backend.exception.ConflictException ex = assertThrows(com.spms.backend.exception.ConflictException.class, () -> 
+            submissionGradeService.submitGrade(submissionId, professorId, request)
+        );
+        assertTrue(ex.getMessage().contains("fully graded"));
+    }
+
+    @Test
+    void submitGrade_PastDeadline_ThrowsForbiddenException() {
+        // Arrange
+        Long submissionId = 1L;
+        Long professorId = 5L;
+        GradeSubmissionRequest request = new GradeSubmissionRequest();
+        request.setGrade(85.0);
+
+        Submission submission = new Submission();
+        submission.setId(submissionId);
+        submission.setStatus(SubmissionStatus.APPROVED);
+
+        Schedule schedule = new Schedule();
+        schedule.setGradingDeadline(java.time.Instant.now().minusSeconds(3600)); // 1 hour ago
+
+        when(submissionRepository.findById(submissionId)).thenReturn(Optional.of(submission));
+        when(scheduleRepository.findTopByOrderByIdDesc()).thenReturn(Optional.of(schedule));
+
+        // Act & Assert
+        com.spms.backend.exception.ForbiddenException ex = assertThrows(com.spms.backend.exception.ForbiddenException.class, () -> 
+            submissionGradeService.submitGrade(submissionId, professorId, request)
+        );
+        assertTrue(ex.getMessage().contains("Grading deadline has passed"));
+    }
+
+
+    @Test
     void submitGrade_CompletesGradingAndNotifies_WhenAllMembersGraded() {
         // Arrange
         Long submissionId = 1L;

--- a/docs/api/P3-Submissions-api.yaml
+++ b/docs/api/P3-Submissions-api.yaml
@@ -515,6 +515,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: |
+            Conflict. Possible causes:
+            - Submission is already fully graded (GRADED status)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
     # TODO: [P3-GRADE-2] NEW ENDPOINT — List grades for a submission
     get:


### PR DESCRIPTION
## Summary
Prevents grading modifications after the D10 deadline or once a submission is already fully graded. This ensures the integrity of the final grades and enforces a hard stop for new grade submissions as per the project schedule.

## AC to Change Mapping

AC | Changes
| :--- | :--- |
Prevent grading of already GRADED submissions | Added logic to `SubmissionGradeService.submitGrade` to check if the submission status is `GRADED` and throw a `ConflictException`. Added a handler in `SubmissionController` to return `409 Conflict`.
Strictly block grading after D10 deadline | Implemented D10 schedule deadline validation within the `submitGrade` method to prevent late entries.
Standardized Error Responses | Updated `SubmissionController` to return spec-compliant `ErrorResponse` payloads (status and message) for both `403` and `409` error cases.
API Contract Alignment | Updated `P3-Submissions-api.yaml` to include the `409 Conflict` response for the grading endpoint.

## Design Rationale
- **Strict Submission Control:** New grade submissions (POST) are now strictly blocked once the terminal `GRADED` state is reached or the D10 deadline has passed. To maintain flexibility for professors, existing grade updates (PUT) remain permitted only for the original grade owners until the hard deadline. (Related issue: #152)
- **Status Mapping:** Confirmed and enforced `GRADED` as the terminal state for Process 3 grading, resolving ambiguity regarding the "FINAL" status mentioned in the issue description.

## Testing
Run the following command in the backend directory to verify the new constraints:

```bash
mvn test -Dtest=SubmissionGradeServiceTest