### PR TITLE
feat(issue-407): implement manual scrum sync button

### DIFF
--- a/frontend/app/groups/[groupId]/page.tsx
+++ b/frontend/app/groups/[groupId]/page.tsx
@@ -9,6 +9,7 @@ import AdvisorRequestPanel from "@/components/AdvisorRequestPanel";
 import StatusBadge from "@/components/StatusBadge";
 import GithubStatusCard from "@/components/GithubStatusCard";
 import JiraStatusCard from "@/components/JiraStatusCard";
+import SyncNowButton from "@/components/SyncNowButton";
 import {
     ApiGroupDetail,
     ApiGroupMember,
@@ -284,6 +285,10 @@ export default function GroupDetailPage() {
                         <StatusBadge
                             status={group.status.toLowerCase() as "forming" | "formed" | "advised" | "disbanded"}
                         />
+                    </div>
+
+                    <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-end gap-4 mb-6 bg-gray-900/50 p-4 rounded-2xl border border-white/5 w-full overflow-hidden">
+                        <SyncNowButton />
                     </div>
 
                     {isLeader && (

--- a/frontend/components/SyncNowButton.tsx
+++ b/frontend/components/SyncNowButton.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { triggerScrumSync } from "@/lib/integrations-api";
+import { showToast } from "@/components/toast/ToastContext";
+
+export default function SyncNowButton() {
+    const [isSyncing, setIsSyncing] = useState(false);
+
+    const handleSync = async () => {
+        setIsSyncing(true);
+        try {
+            const result = await triggerScrumSync();
+            showToast(result.message || "Synchronization successful!", "success");
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "Failed to trigger synchronization.";
+            showToast(message, "error");
+        } finally {
+            setIsSyncing(false);
+        }
+    };
+
+    return (
+        <button
+            onClick={handleSync}
+            disabled={isSyncing}
+            className="flex items-center justify-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-blue-500/20 transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:opacity-70"
+        >
+            {isSyncing ? (
+                <>
+                    <svg className="h-4 w-4 animate-spin text-white" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    <span>Syncing...</span>
+                </>
+            ) : (
+                <>
+                    <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    <span>Sync Now</span>
+                </>
+            )}
+        </button>
+    );
+}


### PR DESCRIPTION
## Description
This PR introduces the "Sync Now" manual trigger functionality on the group details dashboard, allowing users to manually force a synchronization with their external Scrum tools, resolving Issue #407.

## Changes Made
- Created the `<SyncNowButton />` component with internal loading state management.
- Implemented the `triggerScrumSync` API method in `lib/integrations-api.ts`.
- Added visual feedback (a spinning loader and disabled state) while the sync request is in progress to prevent duplicate submissions.
- Integrated the application's global `ToastContext` to display user-friendly success or error notifications (e.g., when the backend integration service is down).

## Acceptance Criteria Met
- [x] "Sync Now" button prominently placed next to the integration status indicator.
- [x] Button provides a spinning loading state during the API call.
- [x] Emits a Global Toast notification indicating the result (success or failure) of the sync attempt.

Closes #407
