### PR TITLE
feat: Integration Status Indicator on Advisor Dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,6 @@ boot_error.log
 # Local notes
 PENDING_FIXES.md
 YONERGE.MD
+yonerge.md
 ISSUE_*_IMPLEMENTATION_PLAN.md
+*-plan.md

--- a/frontend/__tests__/components/IntegrationStatusIndicator.test.tsx
+++ b/frontend/__tests__/components/IntegrationStatusIndicator.test.tsx
@@ -1,0 +1,214 @@
+/* TDD SPECIFICATION: IntegrationStatusIndicator Component
+   Issue: Advisor Dashboard — JIRA & GitHub Integration Status Indicator
+   Covers: Acceptance Criteria (connected/disconnected badge, connectedAt timestamp, skeleton loading)
+*/
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import IntegrationStatusIndicator from '@/components/IntegrationStatusIndicator';
+
+describe('IntegrationStatusIndicator', () => {
+
+    describe('Skeleton Loading State', () => {
+        it('renders skeleton element when loading=true', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={false}
+                    connectedAt={null}
+                    loading={true}
+                    data-testid="github-status"
+                />
+            );
+            expect(screen.getByTestId('github-status-skeleton')).toBeInTheDocument();
+        });
+
+        it('does not render label text when loading=true', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={false}
+                    connectedAt={null}
+                    loading={true}
+                />
+            );
+            expect(screen.queryByText(/GitHub/)).not.toBeInTheDocument();
+        });
+
+        it('skeleton element has animate-pulse class', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="JIRA"
+                    connected={false}
+                    connectedAt={null}
+                    loading={true}
+                    data-testid="jira-status"
+                />
+            );
+            expect(screen.getByTestId('jira-status-skeleton')).toHaveClass('animate-pulse');
+        });
+    });
+
+    describe('Connected State (green badge)', () => {
+        it('renders green bg when connected=true', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={true}
+                    connectedAt={null}
+                    data-testid="github-status"
+                />
+            );
+            expect(screen.getByTestId('github-status')).toHaveClass('bg-green-500/10');
+        });
+
+        it('shows "Connected" label text when connected=true', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={true}
+                    connectedAt={null}
+                />
+            );
+            expect(screen.getByText('GitHub — Connected')).toBeInTheDocument();
+        });
+
+        it('does not render red styling when connected=true', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={true}
+                    connectedAt={null}
+                    data-testid="github-status"
+                />
+            );
+            expect(screen.getByTestId('github-status')).not.toHaveClass('bg-red-500/10');
+        });
+    });
+
+    describe('Disconnected State (red badge)', () => {
+        it('renders red bg when connected=false', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="JIRA"
+                    connected={false}
+                    connectedAt={null}
+                    data-testid="jira-status"
+                />
+            );
+            expect(screen.getByTestId('jira-status')).toHaveClass('bg-red-500/10');
+        });
+
+        it('shows "No Connection" label text when connected=false', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="JIRA"
+                    connected={false}
+                    connectedAt={null}
+                />
+            );
+            expect(screen.getByText('JIRA — No Connection')).toBeInTheDocument();
+        });
+
+        it('does not render green styling when connected=false', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="JIRA"
+                    connected={false}
+                    connectedAt={null}
+                    data-testid="jira-status"
+                />
+            );
+            expect(screen.getByTestId('jira-status')).not.toHaveClass('bg-green-500/10');
+        });
+    });
+
+    describe('connectedAt Timestamp', () => {
+        it('shows "Never connected" when connectedAt is null', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={false}
+                    connectedAt={null}
+                />
+            );
+            expect(screen.getByText('Never connected')).toBeInTheDocument();
+        });
+
+        it('shows "just now" for very recent timestamps', () => {
+            const recent = new Date(Date.now() - 10_000).toISOString();
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={true}
+                    connectedAt={recent}
+                />
+            );
+            expect(screen.getByText('Connected At: just now')).toBeInTheDocument();
+        });
+
+        it('shows minutes ago for timestamps under an hour', () => {
+            const tenMinsAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={true}
+                    connectedAt={tenMinsAgo}
+                />
+            );
+            expect(screen.getByText('Connected At: 10 mins ago')).toBeInTheDocument();
+        });
+
+        it('shows hours ago for timestamps under a day', () => {
+            const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+            render(
+                <IntegrationStatusIndicator
+                    label="JIRA"
+                    connected={true}
+                    connectedAt={threeHoursAgo}
+                />
+            );
+            expect(screen.getByText('Connected At: 3h ago')).toBeInTheDocument();
+        });
+
+        it('shows days ago for timestamps under a month', () => {
+            const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={true}
+                    connectedAt={twoDaysAgo}
+                />
+            );
+            expect(screen.getByText('Connected At: 2d ago')).toBeInTheDocument();
+        });
+    });
+
+    describe('data-testid propagation', () => {
+        it('attaches data-testid to the root element when not loading', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={true}
+                    connectedAt={null}
+                    data-testid="github-status"
+                />
+            );
+            expect(screen.getByTestId('github-status')).toBeInTheDocument();
+        });
+
+        it('attaches data-testid with -skeleton suffix when loading', () => {
+            render(
+                <IntegrationStatusIndicator
+                    label="GitHub"
+                    connected={false}
+                    connectedAt={null}
+                    loading={true}
+                    data-testid="github-status"
+                />
+            );
+            expect(screen.getByTestId('github-status-skeleton')).toBeInTheDocument();
+            expect(screen.queryByTestId('github-status')).not.toBeInTheDocument();
+        });
+    });
+});

--- a/frontend/__tests__/e2e/advisor-integration-status.cy.ts
+++ b/frontend/__tests__/e2e/advisor-integration-status.cy.ts
@@ -1,0 +1,225 @@
+/* E2E SPECIFICATION: Advisor Dashboard — Integration Status Indicators
+   Issue: JIRA & GitHub Connectivity Visual Indicator on Advisor Dashboard
+   Covers: Acceptance Criteria (green/red badge, connectedAt timestamp, skeleton loading)
+   Route: /professor/my-advisees
+*/
+
+describe('Advisor Dashboard — Integration Status Indicators', () => {
+
+    const GROUP_ID = 1;
+
+    const MOCK_ASSIGNMENT = {
+        teamId: GROUP_ID,
+        teamName: 'Team Alpha',
+        leaderName: 'Ali Yılmaz',
+        advisorId: 99,
+        advisorName: 'Prof. Test',
+        status: 'ADVISED',
+        assignedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
+        assignmentType: 'STANDARD',
+    };
+
+    beforeEach(() => {
+        // Auth localStorage keys must match spms_token / spms_user
+        cy.window().then((win) => {
+            win.localStorage.setItem('spms_token', 'mock-professor-token');
+            win.localStorage.setItem('spms_user', JSON.stringify({
+                role: 'professor',
+                requiresPasswordChange: false,
+            }));
+        });
+
+        // fetchAdvisorAssignments expects { status, data: [...] }
+        cy.intercept('GET', '/api/v1/advisor-assignments*', {
+            statusCode: 200,
+            body: {
+                status: 'ok',
+                data: [MOCK_ASSIGNMENT],
+            },
+        }).as('getAdvisees');
+    });
+
+    describe('Skeleton Loading State', () => {
+        it('shows skeleton elements while integration status is loading', () => {
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/github`, (req) => {
+                req.reply({
+                    delay: 1500,
+                    statusCode: 200,
+                    body: { success: true, data: { status: 'active', organizationName: 'org', connectedAt: new Date().toISOString(), message: null } },
+                });
+            }).as('getGithubSlow');
+
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/jira`, (req) => {
+                req.reply({
+                    delay: 1500,
+                    statusCode: 200,
+                    body: { success: true, data: { status: 'active', jiraSpaceUrl: 'https://team.atlassian.net', projectKey: 'TEAM', connectedAt: new Date().toISOString(), message: null } },
+                });
+            }).as('getJiraSlow');
+
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+
+            cy.get(`[data-testid="integration-github-group-${GROUP_ID}-skeleton"]`).should('exist');
+            cy.get(`[data-testid="integration-jira-group-${GROUP_ID}-skeleton"]`).should('exist');
+        });
+    });
+
+    describe('Connected State (green badge)', () => {
+        beforeEach(() => {
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/github`, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    data: {
+                        status: 'active',
+                        organizationName: 'my-org',
+                        connectedAt: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+                        message: null,
+                    },
+                },
+            }).as('getGithub');
+
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/jira`, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    data: {
+                        status: 'active',
+                        jiraSpaceUrl: 'https://team.atlassian.net',
+                        projectKey: 'TEAM',
+                        connectedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+                        message: null,
+                    },
+                },
+            }).as('getJira');
+        });
+
+        it('shows green Connected badge for active GitHub integration', () => {
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+            cy.wait('@getGithub');
+
+            cy.get(`[data-testid="integration-github-group-${GROUP_ID}"]`)
+                .should('be.visible')
+                .and('have.class', 'bg-green-500/10')
+                .and('contain.text', 'GitHub — Connected');
+        });
+
+        it('shows green Connected badge for active JIRA integration', () => {
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+            cy.wait('@getJira');
+
+            cy.get(`[data-testid="integration-jira-group-${GROUP_ID}"]`)
+                .should('be.visible')
+                .and('have.class', 'bg-green-500/10')
+                .and('contain.text', 'JIRA — Connected');
+        });
+
+        it('shows connectedAt timestamp inside the Connected badge', () => {
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+            cy.wait('@getGithub');
+
+            cy.get(`[data-testid="integration-github-group-${GROUP_ID}"]`)
+                .should('contain.text', 'Connected At:');
+        });
+    });
+
+    describe('Disconnected State (red badge)', () => {
+        beforeEach(() => {
+            // GitHub not bound — fetchGithubIntegration handles 404 internally and returns inactive
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/github`, {
+                statusCode: 404,
+                body: { message: 'No GitHub integration exists for this group.' },
+            }).as('getGithubNotFound');
+
+            // JIRA not bound — returns inactive shape
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/jira`, {
+                statusCode: 200,
+                body: {
+                    success: true,
+                    data: {
+                        status: 'inactive',
+                        jiraSpaceUrl: null,
+                        projectKey: null,
+                        connectedAt: null,
+                        message: 'Not connected',
+                    },
+                },
+            }).as('getJiraInactive');
+        });
+
+        it('shows red No Connection badge when GitHub has no integration', () => {
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+            cy.wait('@getGithubNotFound');
+
+            cy.get(`[data-testid="integration-github-group-${GROUP_ID}"]`)
+                .should('be.visible')
+                .and('have.class', 'bg-red-500/10')
+                .and('contain.text', 'GitHub — No Connection');
+        });
+
+        it('shows red No Connection badge when JIRA status is inactive', () => {
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+            cy.wait('@getJiraInactive');
+
+            cy.get(`[data-testid="integration-jira-group-${GROUP_ID}"]`)
+                .should('be.visible')
+                .and('have.class', 'bg-red-500/10')
+                .and('contain.text', 'JIRA — No Connection');
+        });
+
+        it('shows "Never connected" when connectedAt is null', () => {
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+            cy.wait('@getJiraInactive');
+
+            cy.get(`[data-testid="integration-jira-group-${GROUP_ID}"]`)
+                .should('contain.text', 'Never connected');
+        });
+    });
+
+    describe('Both integrations shown per row', () => {
+        it('renders both GitHub and JIRA indicators in the same row', () => {
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/github`, {
+                statusCode: 200,
+                body: { success: true, data: { status: 'active', organizationName: 'org', connectedAt: new Date().toISOString(), message: null } },
+            }).as('getGithub');
+
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/jira`, {
+                statusCode: 200,
+                body: { success: true, data: { status: 'inactive', jiraSpaceUrl: null, projectKey: null, connectedAt: null, message: null } },
+            }).as('getJira');
+
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+            cy.wait('@getGithub');
+            cy.wait('@getJira');
+
+            cy.get(`[data-testid="integration-github-group-${GROUP_ID}"]`).should('exist');
+            cy.get(`[data-testid="integration-jira-group-${GROUP_ID}"]`).should('exist');
+        });
+    });
+
+    describe('Integrations table column', () => {
+        it('renders the Integrations column header', () => {
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/github`, {
+                statusCode: 404,
+                body: {},
+            });
+            cy.intercept('GET', `/api/v1/groups/${GROUP_ID}/integrations/jira`, {
+                statusCode: 200,
+                body: { success: true, data: { status: 'inactive', jiraSpaceUrl: null, projectKey: null, connectedAt: null, message: null } },
+            });
+
+            cy.visit('/professor/my-advisees');
+            cy.wait('@getAdvisees');
+
+            cy.contains('th', 'Integrations').should('be.visible');
+        });
+    });
+});

--- a/frontend/app/professor/my-advisees/page.tsx
+++ b/frontend/app/professor/my-advisees/page.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { getToken, getUser } from "@/lib/auth";
 import Sidebar from "@/components/Sidebar";
+import IntegrationStatusIndicator from "@/components/IntegrationStatusIndicator";
+import { useIntegrationStatus } from "@/hooks/useIntegrationStatus";
 import {
     fetchAdvisorAssignments,
     releaseAdviseeGroup,
@@ -214,7 +216,7 @@ function AdviseesTable() {
                 </div>
 
                 <div className="overflow-x-auto">
-                    <table className="w-full min-w-[900px]">
+                    <table className="w-full min-w-[1100px]">
                         <thead>
                             <tr className="border-b border-white/5">
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Group</th>
@@ -222,68 +224,19 @@ function AdviseesTable() {
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Assigned</th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Source</th>
+                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Integrations</th>
                                 <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                             </tr>
                         </thead>
                         <tbody className="divide-y divide-white/5">
-                            {advisees.map((assignment) => {
-                                const status = assignment.status?.toUpperCase() ?? "UNKNOWN";
-                                const canRelease = status === "ADVISED";
-
-                                return (
-                                    <tr key={assignment.teamId} className="hover:bg-white/[0.02] transition-colors">
-                                        <td className="px-6 py-4">
-                                            <div className="flex items-center gap-3">
-                                                <div className="w-8 h-8 rounded-lg bg-blue-600/10 border border-blue-500/20 flex items-center justify-center shrink-0">
-                                                    <span className="text-xs font-bold text-blue-400 uppercase">
-                                                        {getInitials(assignment.teamName)}
-                                                    </span>
-                                                </div>
-                                                <div className="min-w-0">
-                                                    <p className="text-sm font-medium text-white truncate">{assignment.teamName}</p>
-                                                    <p className="text-xs text-gray-600">Group #{assignment.teamId}</p>
-                                                </div>
-                                            </div>
-                                        </td>
-                                        <td className="px-6 py-4 text-sm text-gray-300">
-                                            {assignment.leaderName || "Not available"}
-                                        </td>
-                                        <td className="px-6 py-4">
-                                            <StatusPill status={status} />
-                                        </td>
-                                        <td className="px-6 py-4 text-sm text-gray-400">
-                                            {assignment.assignedAt ? formatRelativeDate(assignment.assignedAt) : "Not tracked"}
-                                        </td>
-                                        <td className="px-6 py-4">
-                                            <AssignmentTypePill assignmentType={assignment.assignmentType} />
-                                        </td>
-                                        <td className="px-6 py-4 text-right">
-                                            <button
-                                                onClick={() => setConfirmGroupId(assignment.teamId)}
-                                                disabled={releasingId === assignment.teamId || !canRelease}
-                                                title={canRelease ? "Release this advisee group" : "Only advised groups can be released"}
-                                                className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg text-xs font-medium ml-auto
-                                                           bg-red-600/10 border border-red-500/30 text-red-400
-                                                           hover:bg-red-600/20 hover:border-red-500/50 active:scale-95
-                                                           transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-                                            >
-                                                {releasingId === assignment.teamId ? (
-                                                    <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
-                                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                                                    </svg>
-                                                ) : (
-                                                    <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15" />
-                                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 12H9m0 0l3-3m-3 3l3 3" />
-                                                    </svg>
-                                                )}
-                                                Release
-                                            </button>
-                                        </td>
-                                    </tr>
-                                );
-                            })}
+                            {advisees.map((assignment) => (
+                                <AdviseeRow
+                                    key={assignment.teamId}
+                                    assignment={assignment}
+                                    releasingId={releasingId}
+                                    onReleaseClick={() => setConfirmGroupId(assignment.teamId)}
+                                />
+                            ))}
                         </tbody>
                     </table>
                 </div>
@@ -298,6 +251,92 @@ function AdviseesTable() {
                 />
             )}
         </>
+    );
+}
+
+function AdviseeRow({
+    assignment,
+    releasingId,
+    onReleaseClick,
+}: {
+    assignment: AdvisorAssignment;
+    releasingId: number | null;
+    onReleaseClick: () => void;
+}) {
+    const status = assignment.status?.toUpperCase() ?? "UNKNOWN";
+    const canRelease = status === "ADVISED";
+    const { status: integrationStatus, loading: integrationLoading } = useIntegrationStatus(assignment.teamId);
+
+    return (
+        <tr className="hover:bg-white/[0.02] transition-colors">
+            <td className="px-6 py-4">
+                <div className="flex items-center gap-3">
+                    <div className="w-8 h-8 rounded-lg bg-blue-600/10 border border-blue-500/20 flex items-center justify-center shrink-0">
+                        <span className="text-xs font-bold text-blue-400 uppercase">
+                            {getInitials(assignment.teamName)}
+                        </span>
+                    </div>
+                    <div className="min-w-0">
+                        <p className="text-sm font-medium text-white truncate">{assignment.teamName}</p>
+                        <p className="text-xs text-gray-600">Group #{assignment.teamId}</p>
+                    </div>
+                </div>
+            </td>
+            <td className="px-6 py-4 text-sm text-gray-300">
+                {assignment.leaderName || "Not available"}
+            </td>
+            <td className="px-6 py-4">
+                <StatusPill status={status} />
+            </td>
+            <td className="px-6 py-4 text-sm text-gray-400">
+                {assignment.assignedAt ? formatRelativeDate(assignment.assignedAt) : "Not tracked"}
+            </td>
+            <td className="px-6 py-4">
+                <AssignmentTypePill assignmentType={assignment.assignmentType} />
+            </td>
+            <td className="px-6 py-4">
+                <div className="flex flex-col gap-1.5 min-w-[200px]">
+                    <IntegrationStatusIndicator
+                        label="GitHub"
+                        connected={integrationStatus?.github.connected ?? false}
+                        connectedAt={integrationStatus?.github.connectedAt ?? null}
+                        loading={integrationLoading}
+                        data-testid={`integration-github-group-${assignment.teamId}`}
+                    />
+                    <IntegrationStatusIndicator
+                        label="JIRA"
+                        connected={integrationStatus?.jira.connected ?? false}
+                        connectedAt={integrationStatus?.jira.connectedAt ?? null}
+                        loading={integrationLoading}
+                        data-testid={`integration-jira-group-${assignment.teamId}`}
+                    />
+                </div>
+            </td>
+            <td className="px-6 py-4 text-right">
+                <button
+                    onClick={onReleaseClick}
+                    disabled={releasingId === assignment.teamId || !canRelease}
+                    title={canRelease ? "Release this advisee group" : "Only advised groups can be released"}
+                    className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg text-xs font-medium ml-auto
+                               bg-red-600/10 border border-red-500/30 text-red-400
+                               hover:bg-red-600/20 hover:border-red-500/50 active:scale-95
+                               transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                    {releasingId === assignment.teamId ? (
+                        <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                        </svg>
+                    ) : (
+                        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15" />
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 12H9m0 0l3-3m-3 3l3 3" />
+                        </svg>
+                    )}
+                    Release
+                </button>
+            </td>
+        </tr>
     );
 }
 

--- a/frontend/components/IntegrationStatusIndicator.tsx
+++ b/frontend/components/IntegrationStatusIndicator.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+type Props = {
+    label: string;
+    connected: boolean;
+    connectedAt: string | null;
+    loading?: boolean;
+    "data-testid"?: string;
+};
+
+export default function IntegrationStatusIndicator({
+    label,
+    connected,
+    connectedAt,
+    loading = false,
+    "data-testid": testId,
+}: Props) {
+    if (loading) {
+        return (
+            <div
+                data-testid={testId ? `${testId}-skeleton` : undefined}
+                className="animate-pulse flex items-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10"
+            >
+                <div className="w-2 h-2 rounded-full bg-gray-700 flex-shrink-0" />
+                <div className="space-y-1">
+                    <div className="h-2.5 w-20 rounded bg-gray-700" />
+                    <div className="h-2 w-28 rounded bg-gray-700" />
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            data-testid={testId}
+            className={`flex items-center gap-2 px-3 py-2 rounded-lg border transition-all ${
+                connected
+                    ? "bg-green-500/10 border-green-500/20"
+                    : "bg-red-500/10 border-red-500/20"
+            }`}
+        >
+            <div
+                className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                    connected ? "bg-green-400 animate-pulse" : "bg-red-400"
+                }`}
+            />
+            <div className="min-w-0">
+                <p
+                    className={`text-xs font-semibold leading-tight ${
+                        connected ? "text-green-400" : "text-red-400"
+                    }`}
+                >
+                    {label} — {connected ? "Connected" : "No Connection"}
+                </p>
+                <p className="text-xs text-gray-500 leading-tight mt-0.5">
+                    {connectedAt
+                        ? `Connected At: ${formatRelative(connectedAt)}`
+                        : "Never connected"}
+                </p>
+            </div>
+        </div>
+    );
+}
+
+function formatRelative(isoString: string): string {
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return "unknown";
+
+    const diff = Date.now() - date.getTime();
+    if (diff < 0) return "just now";
+
+    const minutes = Math.floor(diff / 60_000);
+    if (minutes < 1) return "just now";
+    if (minutes < 60) return `${minutes} mins ago`;
+
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}d ago`;
+
+    return date.toLocaleDateString("en-US", { day: "2-digit", month: "short", year: "numeric" });
+}

--- a/frontend/hooks/useIntegrationStatus.ts
+++ b/frontend/hooks/useIntegrationStatus.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { fetchGithubIntegration, fetchJiraIntegration } from "@/lib/integrations-api";
+
+export type IntegrationEntry = {
+    connected: boolean;
+    connectedAt: string | null;
+};
+
+export type IntegrationStatusState = {
+    github: IntegrationEntry;
+    jira: IntegrationEntry;
+};
+
+type HookReturn = {
+    status: IntegrationStatusState | null;
+    loading: boolean;
+    error: string | null;
+    refetch: () => void;
+};
+
+export function useIntegrationStatus(groupId: number): HookReturn {
+    const [status, setStatus] = useState<IntegrationStatusState | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+
+        const [githubResult, jiraResult] = await Promise.allSettled([
+            fetchGithubIntegration(groupId),
+            fetchJiraIntegration(groupId),
+        ]);
+
+        const github =
+            githubResult.status === "fulfilled"
+                ? githubResult.value
+                : { data: { status: "inactive", connectedAt: null } };
+
+        const jira =
+            jiraResult.status === "fulfilled"
+                ? jiraResult.value
+                : { data: { status: "inactive", connectedAt: null } };
+
+        const bothFailed =
+            githubResult.status === "rejected" && jiraResult.status === "rejected";
+
+        if (bothFailed) {
+            const msg =
+                githubResult.status === "rejected"
+                    ? (githubResult.reason as Error)?.message ?? "Failed to fetch status"
+                    : "Failed to fetch status";
+            setError(msg);
+            setStatus(null);
+        } else {
+            setStatus({
+                github: {
+                    connected: github.data?.status === "active",
+                    connectedAt: github.data?.connectedAt ?? null,
+                },
+                jira: {
+                    connected: jira.data?.status === "active",
+                    connectedAt: jira.data?.connectedAt ?? null,
+                },
+            });
+        }
+
+        setLoading(false);
+    }, [groupId]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    return { status, loading, error, refetch: load };
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -77,7 +77,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1732,7 +1731,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1840,7 +1838,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -2366,7 +2363,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2869,7 +2865,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3791,7 +3786,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3977,7 +3971,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6880,7 +6873,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -7027,7 +7019,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7037,7 +7028,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8044,7 +8034,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8290,7 +8279,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8737,7 +8725,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

- **New:** `hooks/useIntegrationStatus.ts` — React hook that fetches `GET /api/v1/groups/{groupId}/integrations/github` and `/jira` in parallel via `Promise.allSettled`. A GitHub 404 never silences the JIRA result.
- **New:** `components/IntegrationStatusIndicator.tsx` — visual UX component showing a green/red dot badge with label ("Connected" / "No Connection"), "Connected At: X mins ago" timestamp, and `animate-pulse` skeleton loading state. Accepts `data-testid` for Cypress targeting.
- **Modified:** `app/professor/my-advisees/page.tsx` — table row extracted into `AdviseeRow` sub-component; "Integrations" column added showing GitHub + JIRA indicators per group row.
- **New:** `__tests__/components/IntegrationStatusIndicator.test.tsx` — 14 unit test specifications (skeleton, green badge, red badge, timestamp formatting, data-testid propagation).
- **New:** `__tests__/e2e/advisor-integration-status.cy.ts` — Cypress e2e suite (skeleton loading, green/red badge per integration state, "Never connected", both indicators per row, column header).
- **Modified:** `.gitignore` — added `yonerge.md` and `*-plan.md` to keep local planning files out of version control.

## Backend Compatibility

| Endpoint | Status |
|---|---|
| `GET /api/v1/groups/{id}/integrations/github` | ✅ exists in `GroupController.java` |
| `GET /api/v1/groups/{id}/integrations/jira` | ✅ exists in `GroupController.java` |
| `GET /api/v1/integrations/status` | ⚠️ does NOT exist — intentionally not used |

The issue references `GET /api/v1/integrations/status` but this endpoint is absent from the backend. The implementation uses the per-group endpoints which are live and return the correct `status` + `connectedAt` fields.

## Known Limitation

`connectedAt` in the API response maps to `createdAt` in the backend model (i.e. when the integration was first connected, not the last sync time). The UI label reads "Connected At" which is semantically accurate. True "Last Synced" would require `updatedAt` to be exposed in the backend DTO — that is a separate backend concern.

## Acceptance Criteria Coverage

| Criteria | Implementation |
|---|---|
| `connected: true` → green "Connected" badge | `IntegrationStatusIndicator` applies `bg-green-500/10` and "Connected" text |
| Missing/expired integration → red "No Connection" badge | `status !== "active"` → `connected=false` → red badge |
| "Last Synced" timestamp | "Connected At: X mins ago" using `connectedAt` from API |
| Skeleton loading while API pending | `loading=true` prop renders `animate-pulse` skeleton |

## Test Plan

- [ ] Run Cypress: `npx cypress run --spec "__tests__/e2e/advisor-integration-status.cy.ts"`
- [ ] Verify green badge appears for groups with active GitHub/JIRA integration
- [ ] Verify red badge appears for groups with no integration bound
- [ ] Verify skeleton renders before API responds
- [ ] Verify "Connected At" timestamp displays correctly
- [ ] Verify existing `my-advisees` page functionality (release button, table sorting) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)