### PR TITLE
Fix/jira 2

### DIFF
--- a/backend/src/main/java/com/spms/backend/client/JiraApiClient.java
+++ b/backend/src/main/java/com/spms/backend/client/JiraApiClient.java
@@ -16,11 +16,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 @Component
 public class JiraApiClient {
 
     private static final Logger logger = LoggerFactory.getLogger(JiraApiClient.class);
+    private static final Pattern ISSUE_KEY_PATTERN = Pattern.compile("^[A-Z]+-[0-9]+$");
 
     private final RestClient restClient;
 
@@ -61,6 +63,7 @@ public class JiraApiClient {
             int startAt,
             int maxResults) {
 
+        validateIssueKeys(issueKeys);
         String jql = "issueKey in (" + String.join(",", issueKeys) + ")";
 
         String url = UriComponentsBuilder
@@ -118,6 +121,10 @@ public class JiraApiClient {
                 throw new JiraApiException("JIRA API returned error: " + e.getMessage());
             }
 
+            if (response == null) {
+                throw new JiraApiException("Empty response from JIRA API");
+            }
+
             total = ((Number) response.getOrDefault("total", 0)).intValue();
 
             @SuppressWarnings("unchecked")
@@ -138,5 +145,16 @@ public class JiraApiClient {
 
         logger.info("JQL query fetched {} / {} issues", allKeys.size(), total);
         return allKeys;
+    }
+
+    private void validateIssueKeys(List<String> issueKeys) {
+        if (issueKeys == null || issueKeys.isEmpty()) {
+            throw new JiraApiException("Issue keys list cannot be empty");
+        }
+        for (String key : issueKeys) {
+            if (!ISSUE_KEY_PATTERN.matcher(key).matches()) {
+                throw new JiraApiException("Invalid issue key format: " + key);
+            }
+        }
     }
 }

--- a/backend/src/main/java/com/spms/backend/client/JiraApiClient.java
+++ b/backend/src/main/java/com/spms/backend/client/JiraApiClient.java
@@ -13,10 +13,12 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class JiraApiClient {
@@ -30,7 +32,7 @@ public class JiraApiClient {
         this.restClient = restClientBuilder.build();
     }
 
-    public boolean validateSpaceConnection(String jiraSpaceUrl, String projectKey, String apiKey) {
+    public boolean validateSpaceConnection(String jiraSpaceUrl, String projectKey, String email, String apiKey) {
         String normalizedBaseUrl = jiraSpaceUrl != null ? jiraSpaceUrl.trim() : "";
         String normalizedProjectKey = projectKey != null ? projectKey.trim() : "";
 
@@ -45,8 +47,10 @@ public class JiraApiClient {
                     .uri(validationUrl)
                     .accept(MediaType.APPLICATION_JSON);
 
-            if (StringUtils.hasText(apiKey)) {
-                request = request.header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.trim());
+            if (StringUtils.hasText(email) && StringUtils.hasText(apiKey)) {
+                String auth = Base64.getEncoder().encodeToString(
+                    (email.trim() + ":" + apiKey.trim()).getBytes(StandardCharsets.UTF_8));
+                request = request.header(HttpHeaders.AUTHORIZATION, "Basic " + auth);
             }
 
             request.retrieve().toBodilessEntity();
@@ -58,6 +62,7 @@ public class JiraApiClient {
 
     public Map<String, Object> fetchIssuesBatch(
             String jiraBaseUrl,
+            String email,
             String apiKey,
             List<String> issueKeys,
             int startAt,
@@ -77,9 +82,11 @@ public class JiraApiClient {
                 .toUriString();
 
         try {
+            String auth = Base64.getEncoder().encodeToString(
+                (email.trim() + ":" + apiKey.trim()).getBytes(StandardCharsets.UTF_8));
             return restClient.get()
                     .uri(url)
-                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.trim())
+                    .header(HttpHeaders.AUTHORIZATION, "Basic " + auth)
                     .accept(MediaType.APPLICATION_JSON)
                     .retrieve()
                     .body(new ParameterizedTypeReference<Map<String, Object>>() {});
@@ -89,7 +96,7 @@ public class JiraApiClient {
         }
     }
 
-    public List<String> searchIssuesByJql(String jiraBaseUrl, String apiKey, String jql) {
+    public List<String> searchIssuesByJql(String jiraBaseUrl, String email, String apiKey, String jql) {
         List<String> allKeys = new ArrayList<>();
         int startAt = 0;
         int maxResults = 100;
@@ -101,6 +108,9 @@ public class JiraApiClient {
                 .build()
                 .toUriString();
 
+        String auth = Base64.getEncoder().encodeToString(
+            (email.trim() + ":" + apiKey.trim()).getBytes(StandardCharsets.UTF_8));
+
         do {
             String requestBody = String.format(
                     "{\"jql\":\"%s\",\"startAt\":%d,\"maxResults\":%d,\"fields\":[\"summary\"]}",
@@ -110,7 +120,7 @@ public class JiraApiClient {
             try {
                 response = restClient.post()
                         .uri(url)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey.trim())
+                        .header(HttpHeaders.AUTHORIZATION, "Basic " + auth)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .body(requestBody)

--- a/backend/src/main/java/com/spms/backend/config/RestClientConfig.java
+++ b/backend/src/main/java/com/spms/backend/config/RestClientConfig.java
@@ -3,12 +3,17 @@ package com.spms.backend.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import java.time.Duration;
 
 @Configuration
 public class RestClientConfig {
 
     @Bean
     public RestClient.Builder restClientBuilder() {
-        return RestClient.builder();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(5));
+        factory.setReadTimeout(Duration.ofSeconds(30));
+        return RestClient.builder().requestFactory(factory);
     }
 }

--- a/backend/src/main/java/com/spms/backend/converter/EncryptionConverter.java
+++ b/backend/src/main/java/com/spms/backend/converter/EncryptionConverter.java
@@ -2,29 +2,34 @@ package com.spms.backend.converter;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 @Component
 @Converter
 public class EncryptionConverter implements AttributeConverter<String, String> {
     private static final String ALGORITHM = "AES";
-    
-    // Gerçek projede @Value ile application.yml'den al, şimdilik sabit:
-    private static final byte[] KEY = "MySuperSecretKey1234567890123456".getBytes(); 
+
+    private final byte[] key;
+
+    public EncryptionConverter(@Value("${jira.encryption.key}") String encryptionKey) {
+        this.key = encryptionKey.getBytes(StandardCharsets.UTF_8);
+    }
 
     @Override
     public String convertToDatabaseColumn(String attribute) {
         if (attribute == null) return null;
         try {
             Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(KEY, ALGORITHM));
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(key, ALGORITHM));
             return Base64.getEncoder().encodeToString(cipher.doFinal(attribute.getBytes()));
         } catch (Exception e) {
-            throw new RuntimeException("Error encrypting PAT", e);
+            throw new RuntimeException("Error encrypting API key", e);
         }
     }
 
@@ -33,10 +38,10 @@ public class EncryptionConverter implements AttributeConverter<String, String> {
         if (dbData == null) return null;
         try {
             Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(KEY, ALGORITHM));
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(key, ALGORITHM));
             return new String(cipher.doFinal(Base64.getDecoder().decode(dbData)));
         } catch (Exception e) {
-            throw new RuntimeException("Error decrypting PAT", e);
+            throw new RuntimeException("Error decrypting API key", e);
         }
     }
 }

--- a/backend/src/main/java/com/spms/backend/dto/request/JiraBindingRequest.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/JiraBindingRequest.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 public record JiraBindingRequest(
         @NotBlank(message = "jiraSpaceUrl is required.")
         String jiraSpaceUrl,
+        @NotBlank(message = "email is required.")
+        String email,
         String apiKey,
         @NotBlank(message = "projectKey is required.")
         String projectKey

--- a/backend/src/main/java/com/spms/backend/dto/request/JiraIssueDetailsRequest.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/JiraIssueDetailsRequest.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public record JiraIssueDetailsRequest(
     @NotBlank String jiraSpaceUrl,
+    @NotBlank String email,
     @NotBlank String apiKey,
     @NotNull  List<String> issueKeys
 ) {}

--- a/backend/src/main/java/com/spms/backend/model/JiraIntegration.java
+++ b/backend/src/main/java/com/spms/backend/model/JiraIntegration.java
@@ -27,6 +27,9 @@ public class JiraIntegration {
     @Column(name = "project_key", nullable = false)
     private String projectKey;
 
+    @Column(name = "email", nullable = false)
+    private String email;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private JiraIntegrationStatus status = JiraIntegrationStatus.ACTIVE;
@@ -78,6 +81,14 @@ public class JiraIntegration {
 
     public void setProjectKey(String projectKey) {
         this.projectKey = projectKey;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
     }
 
     public JiraIntegrationStatus getStatus() {

--- a/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/GroupServiceImpl.java
@@ -264,7 +264,7 @@ public class GroupServiceImpl implements GroupService {
         ensureRequesterIsGroupLeader(group, requesterId);
 
         boolean valid = jiraApiClient.validateSpaceConnection(request.jiraSpaceUrl(), request.projectKey(),
-                request.apiKey());
+                request.email(), request.apiKey());
         if (!valid) {
             throw new BadRequestException("JIRA connection validation failed.");
         }
@@ -272,6 +272,7 @@ public class GroupServiceImpl implements GroupService {
         JiraIntegration integration = jiraIntegrationRepository.findByGroup_Id(groupId)
                 .orElseGet(JiraIntegration::new);
         integration.setGroup(group);
+        integration.setEmail(request.email());
         integration.setJiraSpaceUrl(request.jiraSpaceUrl().trim());
         integration.setApiKey(request.apiKey() != null ? request.apiKey().trim() : null);
         integration.setProjectKey(request.projectKey().trim());
@@ -849,7 +850,7 @@ public class GroupServiceImpl implements GroupService {
         var jiraOpt = jiraIntegrationRepository.findByGroup_Id(groupId);
         if (jiraOpt.isPresent()) {
             jiraConnected = jiraApiClient.validateSpaceConnection(
-                    jiraOpt.get().getJiraSpaceUrl(), jiraOpt.get().getProjectKey(), jiraOpt.get().getApiKey());
+                    jiraOpt.get().getJiraSpaceUrl(), jiraOpt.get().getProjectKey(), jiraOpt.get().getEmail(), jiraOpt.get().getApiKey());
             jiraMsg = jiraConnected ? "Connected" : "Jira credentials invalid";
         }
 

--- a/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
@@ -67,6 +67,10 @@ public class JiraMetricsServiceImpl implements JiraMetricsService {
                 throw e;
             }
 
+            if (response == null) {
+                throw new JiraApiException("Empty response from JIRA API during batch fetch");
+            }
+
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> issueList =
                     (List<Map<String, Object>>) response.getOrDefault("issues", Collections.emptyList());
@@ -75,7 +79,7 @@ public class JiraMetricsServiceImpl implements JiraMetricsService {
                 results.add(extractCleansedIssue(raw));
             }
 
-            startAt += BATCH_SIZE;
+            startAt += batch.size();
         }
 
         logger.info("Issue details fetched: {}/{} keys resolved", results.size(), keys.size());

--- a/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
@@ -61,7 +61,7 @@ public class JiraMetricsServiceImpl implements JiraMetricsService {
             Map<String, Object> response;
             try {
                 response = jiraApiClient.fetchIssuesBatch(
-                        request.jiraSpaceUrl(), request.apiKey(), batch, 0, BATCH_SIZE);
+                        request.jiraSpaceUrl(), request.email(), request.apiKey(), batch, 0, BATCH_SIZE);
             } catch (JiraApiException e) {
                 logger.error("JIRA API error during batch fetch (startAt={}): {}", startAt, e.getMessage());
                 throw e;
@@ -96,6 +96,7 @@ public class JiraMetricsServiceImpl implements JiraMetricsService {
         boolean connected = jiraApiClient.validateSpaceConnection(
                 integration.getJiraSpaceUrl(),
                 integration.getProjectKey(),
+                integration.getEmail(),
                 integration.getApiKey());
 
         String message = connected
@@ -122,6 +123,7 @@ public class JiraMetricsServiceImpl implements JiraMetricsService {
         try {
             issueKeys = jiraApiClient.searchIssuesByJql(
                     integration.getJiraSpaceUrl(),
+                    integration.getEmail(),
                     integration.getApiKey(),
                     request.jql());
         } catch (JiraApiException e) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -37,3 +37,7 @@ token:
 scrum:
   sync:
     cron: ${SCRUM_SYNC_CRON:0 0 2 * * *}
+
+jira:
+  encryption:
+    key: ${JIRA_ENCRYPTION_KEY}

--- a/backend/src/main/resources/db/migration/V8__Add_Email_To_Jira_Integrations.sql
+++ b/backend/src/main/resources/db/migration/V8__Add_Email_To_Jira_Integrations.sql
@@ -1,0 +1,5 @@
+ALTER TABLE jira_integrations
+ADD COLUMN email VARCHAR(255) NOT NULL DEFAULT '';
+
+ALTER TABLE jira_integrations
+ALTER COLUMN email DROP DEFAULT;

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -28,3 +28,7 @@ scrum:
 token:
   secret: test-secret-key-for-testing-only
   expiration-seconds: 3600
+
+jira:
+  encryption:
+    key: TestSuperSecretKey1234567890Test


### PR DESCRIPTION
 Add email field to JiraIntegration model with database migration and update Jira API authentication from Bearer token to Basic Auth using base64-encoded email:apiKey. Update all   JiraApiClient methods and their callers to properly handle email parameter for correct Jira API v3 authentication.   