### PR TITLE
Fix: Leaderboard API and hydration mismatch in committee details

### DIFF
--- a/frontend/__tests__/e2e/performance-dashboards.cy.ts
+++ b/frontend/__tests__/e2e/performance-dashboards.cy.ts
@@ -9,8 +9,8 @@ describe('Performance Dashboards & Charts E2E Tests', () => {
       statusCode: 200,
       body: {
         content: [
-          { studentId: 1, name: 'Alice', storyPoints: 40, ratio: 0.95 },
-          { studentId: 2, name: 'Bob', storyPoints: 20, ratio: 0.50 }
+          { studentId: 1, name: 'Alice', assignedSp: 42, accomplishedSp: 40, ratio: 0.95 },
+          { studentId: 2, name: 'Bob', assignedSp: 40, accomplishedSp: 20, ratio: 0.50 }
         ],
         totalPages: 5,
         totalElements: 50

--- a/frontend/app/committees/[committeeId]/page.tsx
+++ b/frontend/app/committees/[committeeId]/page.tsx
@@ -13,8 +13,12 @@ export default function CommitteeDetailPage() {
     const params = useParams();
     const committeeId = Number(params.committeeId);
 
-    const currentUser = getUser();
-    const isCoordinator = currentUser?.role === "coordinator";
+    const [isCoordinator, setIsCoordinator] = useState(false);
+
+    useEffect(() => {
+        const currentUser = getUser();
+        setIsCoordinator(currentUser?.role === "coordinator");
+    }, []);
 
     const [committee, setCommittee] = useState<CommitteeDetail | null>(null);
     const [loading, setLoading] = useState(true);

--- a/frontend/lib/analytics-api.ts
+++ b/frontend/lib/analytics-api.ts
@@ -1,0 +1,51 @@
+import { API_BASE, buildHeaders, parseError } from "./api-utils";
+
+export interface StudentPerformanceDto {
+    studentId: number;
+    name: string;
+    assignedSp: number;
+    accomplishedSp: number;
+    ratio: number;
+}
+
+export interface LeaderboardResponse {
+    content: StudentPerformanceDto[];
+    totalPages: number;
+    totalElements: number;
+}
+
+/**
+ * Fetches the student leaderboard data from the analytics API.
+ * 
+ * @param page 0-indexed page number
+ * @param size number of records per page
+ * @param sortField field to sort by (name, assignedSp, accomplishedSp, ratio)
+ * @param sortDir direction to sort (asc, desc)
+ */
+export async function fetchLeaderboard(
+    page: number = 0,
+    size: number = 10,
+    sortField: string = "ratio",
+    sortDir: string = "desc"
+): Promise<LeaderboardResponse> {
+    // Map frontend sort fields to backend property paths
+    // 'name' maps to 'user.fullName' since 'name' is in the DTO but sorting happens on the Entity
+    const backendSortField = sortField === "name" ? "user.fullName" : sortField;
+    
+    const params = new URLSearchParams({
+        page: String(page),
+        size: String(size),
+        sort: `${backendSortField},${sortDir}`,
+    });
+
+    const res = await fetch(`${API_BASE}/analytics/leaderboard?${params.toString()}`, {
+        headers: buildHeaders(),
+        cache: "no-store",
+    });
+
+    if (!res.ok) {
+        throw new Error(await parseError(res));
+    }
+
+    return res.json();
+}


### PR DESCRIPTION
### Description
This PR addresses two main issues: a missing API implementation for the Leaderboard and a hydration mismatch error in the Committee Detail page.

#### Key Changes:
- **Leaderboard Integration:**
    - Created `frontend/lib/analytics-api.ts` to handle data fetching for the student leaderboard.
    - Implemented `fetchLeaderboard` with support for pagination and sorting.
    - Added a mapping for the "name" field to `user.fullName` to ensure compatibility with the backend sorting logic.
    - Updated the E2E test mock data in `performance-dashboards.cy.ts` to align with the actual `StudentPerformanceDto` structure (`assignedSp`, `accomplishedSp`).

- **Hydration Error Fix:**
    - Fixed a "Hydration Mismatch" error in `app/committees/[committeeId]/page.tsx`.
    - Moved the client-side `getUser()` check into a `useEffect` hook. This ensures that the initial server-side render matches the first client-side render, preventing React from throwing an error when accessing `localStorage` data.

### Verification Results
- **Leaderboard:** Verified that the component now has access to the necessary types and API functions.
- **Hydration:** Confirmed that the `Back to committees` link and coordinator-specific buttons no longer cause hydration errors when accessed by a logged-in user.
- **Types:** All TypeScript errors related to missing analytics imports have been resolved.
