### PR TITLE
feat: add GET/PUT /ai-validation/config endpoints + coordinator form (Resolves #298)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/AiValidationConfigController.java
+++ b/backend/src/main/java/com/spms/backend/controller/AiValidationConfigController.java
@@ -1,0 +1,89 @@
+package com.spms.backend.controller;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: AiValidationConfigService.java, ValidationConfigRequest.java,
+//            ValidationConfigResponse.java, P7-AI-Validation-api.yaml §7.0 Configuration
+//   Coordinate before editing: check with team
+
+import com.spms.backend.dto.request.ValidationConfigRequest;
+import com.spms.backend.dto.response.ValidationConfigResponse;
+import com.spms.backend.exception.ForbiddenException;
+import com.spms.backend.service.AiValidationConfigService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * REST controller for AI validation configuration endpoints.
+ *
+ * <pre>
+ * GET  /api/v1/ai-validation/config  — Read current config  (Coordinator only)
+ * PUT  /api/v1/ai-validation/config  — Update config        (Coordinator only)
+ * </pre>
+ *
+ * <p>DFD: Process 7.0 Configuration — Issue #298.<br>
+ * Spec: P7-AI-Validation-api.yaml §7.0 Configuration tag.</p>
+ */
+@Tag(name = "7.0 Configuration", description = "Configure AI validation weights, thresholds, and OpenAI model parameters")
+@RestController
+@RequestMapping("/api/v1/ai-validation/config")
+public class AiValidationConfigController {
+
+    private final AiValidationConfigService configService;
+
+    public AiValidationConfigController(AiValidationConfigService configService) {
+        this.configService = configService;
+    }
+
+    /**
+     * GET /api/v1/ai-validation/config
+     *
+     * <p>Returns the current AI validation configuration.</p>
+     *
+     * <p>Authorization: COORDINATOR only. Advisor/Student → 403.</p>
+     */
+    @Operation(summary = "Get AI validation configuration (Coordinator only)")
+    @GetMapping
+    public ResponseEntity<ValidationConfigResponse> getConfig(HttpServletRequest httpReq) {
+        requireCoordinator(httpReq);
+        return ResponseEntity.ok(configService.getConfig());
+    }
+
+    /**
+     * PUT /api/v1/ai-validation/config
+     *
+     * <p>Updates the AI validation configuration. Changes apply to future
+     * validation runs only — existing results are not recalculated.</p>
+     *
+     * <p>Authorization: COORDINATOR only. Advisor/Student → 403.</p>
+     *
+     * <p>Validation errors → 400 with errorCode encoded in the message field:
+     * {@code INVALID_WEIGHTS}, {@code INVALID_MAX_DIFF_LINES}, {@code INVALID_OPENAI_MODEL}.</p>
+     */
+    @Operation(summary = "Update AI validation configuration (Coordinator only)")
+    @PutMapping
+    public ResponseEntity<ValidationConfigResponse> updateConfig(
+            @Valid @RequestBody ValidationConfigRequest request,
+            HttpServletRequest httpReq) {
+        requireCoordinator(httpReq);
+        return ResponseEntity.ok(configService.updateConfig(request));
+    }
+
+    // ── Private helpers ─────────────────────────────────────────────────
+
+    /**
+     * Reads {@code jwt_role} from the request attributes (set by the JWT filter)
+     * and throws {@link ForbiddenException} if the caller is not a coordinator.
+     *
+     * <p>The spec says: "Advisor / Student token → 403 FORBIDDEN".</p>
+     */
+    private void requireCoordinator(HttpServletRequest httpReq) {
+        Object role = httpReq.getAttribute("jwt_role");
+        if (!"coordinator".equals(role)) {
+            throw new ForbiddenException("FORBIDDEN: Only coordinators can access the AI validation configuration.");
+        }
+    }
+}

--- a/backend/src/main/java/com/spms/backend/converter/StringListConverter.java
+++ b/backend/src/main/java/com/spms/backend/converter/StringListConverter.java
@@ -1,0 +1,49 @@
+package com.spms.backend.converter;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: ValidationConfig.java, AiValidationConfigServiceImpl.java, V12 migration
+//   Coordinate before editing: check with team
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Converts {@code List<String>} ↔ comma-separated {@code TEXT} column.
+ * <p>
+ * An empty list is stored as an empty string {@code ""} and is read back
+ * as an empty list (never {@code null}), satisfying the spec rule:
+ * "excludedFilePatterns: [] → stored as empty array; subsequent GET returns [] (never null)".
+ * </p>
+ */
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "";
+        }
+        return attribute.stream()
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.trim().isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(dbData.split(DELIMITER, -1))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/spms/backend/dto/request/ValidationConfigRequest.java
+++ b/backend/src/main/java/com/spms/backend/dto/request/ValidationConfigRequest.java
@@ -1,0 +1,33 @@
+package com.spms.backend.dto.request;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: AiValidationConfigController.java, AiValidationConfigServiceImpl.java
+//   Coordinate before editing: check with team
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+/**
+ * Request body for {@code PUT /api/v1/ai-validation/config}.
+ *
+ * <p>Spec: {@code ValidationConfigRequest} in P7-AI-Validation-api.yaml §Schemas.</p>
+ *
+ * <p>Required fields: {@code reviewWeight}, {@code implementationWeight}.
+ * Optional: {@code openaiModel}, {@code maxDiffLines}, {@code excludedFilePatterns}.</p>
+ */
+public record ValidationConfigRequest(
+
+        @NotNull(message = "reviewWeight is required")
+        Integer reviewWeight,
+
+        @NotNull(message = "implementationWeight is required")
+        Integer implementationWeight,
+
+        String openaiModel,
+
+        Integer maxDiffLines,
+
+        List<String> excludedFilePatterns
+) {
+}

--- a/backend/src/main/java/com/spms/backend/dto/response/ValidationConfigResponse.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/ValidationConfigResponse.java
@@ -1,0 +1,41 @@
+package com.spms.backend.dto.response;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: AiValidationConfigController.java, AiValidationConfigServiceImpl.java
+//   Coordinate before editing: check with team
+
+import java.util.List;
+
+/**
+ * Response DTO for {@code GET /api/v1/ai-validation/config} and
+ * {@code PUT /api/v1/ai-validation/config}.
+ *
+ * <p>Spec shape (P7-AI-Validation-api.yaml §ValidationConfigResponse):
+ * <pre>
+ * {
+ *   "status": "success",
+ *   "data": {
+ *     "reviewWeight": 40,
+ *     "implementationWeight": 60,
+ *     "openaiModel": "gpt-4o",
+ *     "maxDiffLines": 500,
+ *     "excludedFilePatterns": []
+ *   }
+ * }
+ * </pre>
+ * </p>
+ */
+public record ValidationConfigResponse(
+        String status,
+        ValidationConfigData data
+) {
+
+    public record ValidationConfigData(
+            int reviewWeight,
+            int implementationWeight,
+            String openaiModel,
+            int maxDiffLines,
+            List<String> excludedFilePatterns
+    ) {
+    }
+}

--- a/backend/src/main/java/com/spms/backend/model/ValidationConfig.java
+++ b/backend/src/main/java/com/spms/backend/model/ValidationConfig.java
@@ -1,0 +1,74 @@
+package com.spms.backend.model;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: V12 migration, ValidationConfigRepository.java, AiValidationConfigServiceImpl.java,
+//            StringListConverter.java
+//   Coordinate before editing: check with team
+
+import com.spms.backend.converter.StringListConverter;
+import jakarta.persistence.*;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * JPA entity for the {@code validation_config} singleton table.
+ * <p>
+ * There is exactly one row in this table (id = 1). The entity is never
+ * constructed directly by application code — it is loaded via
+ * {@link com.spms.backend.repository.ValidationConfigRepository#findById(Object)}.
+ * </p>
+ *
+ * <p>DFD reference: Process 7 / Issue #298 — "Config GET/PUT Endpoints".</p>
+ */
+@Entity
+@Table(name = "validation_config")
+public class ValidationConfig {
+
+    @Id
+    private Long id;
+
+    @Column(name = "review_weight", nullable = false)
+    private int reviewWeight;
+
+    @Column(name = "implementation_weight", nullable = false)
+    private int implementationWeight;
+
+    @Column(name = "openai_model", nullable = false, length = 50)
+    private String openaiModel;
+
+    @Column(name = "max_diff_lines", nullable = false)
+    private int maxDiffLines;
+
+    /**
+     * Stored as a comma-delimited TEXT column; converted via
+     * {@link StringListConverter}.  Always returns a non-null list.
+     */
+    @Convert(converter = StringListConverter.class)
+    @Column(name = "excluded_file_patterns", nullable = false)
+    private List<String> excludedFilePatterns = Collections.emptyList();
+
+    // ── Getters / setters ──────────────────────────────────────────────
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public int getReviewWeight() { return reviewWeight; }
+    public void setReviewWeight(int reviewWeight) { this.reviewWeight = reviewWeight; }
+
+    public int getImplementationWeight() { return implementationWeight; }
+    public void setImplementationWeight(int implementationWeight) { this.implementationWeight = implementationWeight; }
+
+    public String getOpenaiModel() { return openaiModel; }
+    public void setOpenaiModel(String openaiModel) { this.openaiModel = openaiModel; }
+
+    public int getMaxDiffLines() { return maxDiffLines; }
+    public void setMaxDiffLines(int maxDiffLines) { this.maxDiffLines = maxDiffLines; }
+
+    public List<String> getExcludedFilePatterns() {
+        return excludedFilePatterns == null ? Collections.emptyList() : excludedFilePatterns;
+    }
+    public void setExcludedFilePatterns(List<String> excludedFilePatterns) {
+        this.excludedFilePatterns = excludedFilePatterns == null ? Collections.emptyList() : excludedFilePatterns;
+    }
+}

--- a/backend/src/main/java/com/spms/backend/repository/ValidationConfigRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/ValidationConfigRepository.java
@@ -1,0 +1,17 @@
+package com.spms.backend.repository;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: ValidationConfig.java, AiValidationConfigServiceImpl.java
+//   Coordinate before editing: check with team
+
+import com.spms.backend.model.ValidationConfig;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Repository for the {@code validation_config} singleton table.
+ * Always use {@code findById(1L)} to retrieve the sole row.
+ */
+@Repository
+public interface ValidationConfigRepository extends JpaRepository<ValidationConfig, Long> {
+}

--- a/backend/src/main/java/com/spms/backend/service/AiValidationConfigService.java
+++ b/backend/src/main/java/com/spms/backend/service/AiValidationConfigService.java
@@ -1,0 +1,40 @@
+package com.spms.backend.service;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: AiValidationConfigServiceImpl.java, AiValidationConfigController.java
+//   Coordinate before editing: check with team
+
+import com.spms.backend.dto.request.ValidationConfigRequest;
+import com.spms.backend.dto.response.ValidationConfigResponse;
+
+/**
+ * Service interface for reading and updating the AI validation configuration
+ * singleton (Process 7, Issue #298).
+ */
+public interface AiValidationConfigService {
+
+    /**
+     * Returns the current AI validation configuration.
+     *
+     * @return the config wrapped in {@link ValidationConfigResponse}
+     */
+    ValidationConfigResponse getConfig();
+
+    /**
+     * Validates and applies an updated configuration.
+     *
+     * <p>Business rules enforced:
+     * <ul>
+     *   <li>{@code reviewWeight + implementationWeight} must equal 100 → {@code INVALID_WEIGHTS}</li>
+     *   <li>{@code maxDiffLines} (if provided) must be ≥ 1 → {@code INVALID_MAX_DIFF_LINES}</li>
+     *   <li>{@code openaiModel} (if provided) must be one of the whitelisted values
+     *       → {@code INVALID_OPENAI_MODEL}</li>
+     * </ul>
+     * </p>
+     *
+     * @param request the new configuration values
+     * @return the updated config wrapped in {@link ValidationConfigResponse}
+     * @throws com.spms.backend.exception.BadRequestException on constraint violations
+     */
+    ValidationConfigResponse updateConfig(ValidationConfigRequest request);
+}

--- a/backend/src/main/java/com/spms/backend/service/impl/AiValidationConfigServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/AiValidationConfigServiceImpl.java
@@ -1,0 +1,148 @@
+package com.spms.backend.service.impl;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: AiValidationConfigService.java, ValidationConfig.java, ValidationConfigRepository.java,
+//            ValidationConfigRequest.java, ValidationConfigResponse.java
+//   Coordinate before editing: check with team
+
+import com.spms.backend.dto.request.ValidationConfigRequest;
+import com.spms.backend.dto.response.ValidationConfigResponse;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.model.ValidationConfig;
+import com.spms.backend.repository.ValidationConfigRepository;
+import com.spms.backend.service.AiValidationConfigService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Implementation of {@link AiValidationConfigService}.
+ *
+ * <p>DFD reference: Process 7.0 Configuration — Issue #298.</p>
+ *
+ * <p><strong>Security note:</strong> log only IDs and counts, never raw
+ * model names or pattern lists, to prevent accidental PII / key leakage
+ * via log aggregation.</p>
+ */
+@Service
+public class AiValidationConfigServiceImpl implements AiValidationConfigService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AiValidationConfigServiceImpl.class);
+
+    /** Singleton row ID — always 1. */
+    private static final long CONFIG_ID = 1L;
+
+    /** Allowed OpenAI model identifiers (spec-specified whitelist). */
+    private static final Set<String> ALLOWED_MODELS = Set.of(
+            "gpt-4o",
+            "gpt-4o-mini",
+            "gpt-4-turbo"
+    );
+
+    private final ValidationConfigRepository configRepository;
+
+    public AiValidationConfigServiceImpl(ValidationConfigRepository configRepository) {
+        this.configRepository = configRepository;
+    }
+
+    // ── GET ──────────────────────────────────────────────────────────────
+
+    @Override
+    public ValidationConfigResponse getConfig() {
+        ValidationConfig config = loadSingleton();
+        logger.info("AI validation config retrieved (id={})", CONFIG_ID);
+        return toResponse(config);
+    }
+
+    // ── PUT ──────────────────────────────────────────────────────────────
+
+    @Override
+    @Transactional
+    public ValidationConfigResponse updateConfig(ValidationConfigRequest request) {
+        validate(request);
+
+        ValidationConfig config = loadSingleton();
+
+        config.setReviewWeight(request.reviewWeight());
+        config.setImplementationWeight(request.implementationWeight());
+
+        if (request.openaiModel() != null) {
+            config.setOpenaiModel(request.openaiModel());
+        }
+        if (request.maxDiffLines() != null) {
+            config.setMaxDiffLines(request.maxDiffLines());
+        }
+
+        // excludedFilePatterns: null in request → keep existing; empty list → store empty
+        if (request.excludedFilePatterns() != null) {
+            config.setExcludedFilePatterns(request.excludedFilePatterns());
+        }
+
+        ValidationConfig saved = configRepository.save(config);
+
+        // Log pattern count, not raw patterns (no PII leakage)
+        logger.info("AI validation config updated (id={}, reviewWeight={}, implementationWeight={}, " +
+                        "patternCount={})",
+                CONFIG_ID,
+                saved.getReviewWeight(),
+                saved.getImplementationWeight(),
+                saved.getExcludedFilePatterns().size());
+
+        return toResponse(saved);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    /**
+     * Loads the singleton config row or throws if missing (should never happen
+     * because the V12 migration inserts the default row).
+     */
+    private ValidationConfig loadSingleton() {
+        return configRepository.findById(CONFIG_ID)
+                .orElseThrow(() -> new IllegalStateException(
+                        "validation_config singleton row (id=1) is missing — check V12 migration."));
+    }
+
+    /**
+     * Enforces all spec-mandated business rules and throws
+     * {@link BadRequestException} with the spec error code encoded in the
+     * message (option-2 decision: errorCode encoded in message field).
+     */
+    private void validate(ValidationConfigRequest request) {
+        // Rule 1: weights must sum to 100
+        if (request.reviewWeight() + request.implementationWeight() != 100) {
+            throw new BadRequestException("INVALID_WEIGHTS: reviewWeight + implementationWeight must equal 100.");
+        }
+
+        // Rule 2: maxDiffLines, if provided, must be >= 1
+        if (request.maxDiffLines() != null && request.maxDiffLines() < 1) {
+            throw new BadRequestException("INVALID_MAX_DIFF_LINES: maxDiffLines must be at least 1.");
+        }
+
+        // Rule 3: openaiModel, if provided, must be in the whitelist
+        if (request.openaiModel() != null && !ALLOWED_MODELS.contains(request.openaiModel())) {
+            throw new BadRequestException(
+                    "INVALID_OPENAI_MODEL: openaiModel must be one of " + ALLOWED_MODELS + ".");
+        }
+    }
+
+    /** Maps a {@link ValidationConfig} entity to the spec response envelope. */
+    private static ValidationConfigResponse toResponse(ValidationConfig config) {
+        List<String> patterns = config.getExcludedFilePatterns();
+        return new ValidationConfigResponse(
+                "success",
+                new ValidationConfigResponse.ValidationConfigData(
+                        config.getReviewWeight(),
+                        config.getImplementationWeight(),
+                        config.getOpenaiModel(),
+                        config.getMaxDiffLines(),
+                        patterns == null ? Collections.emptyList() : patterns
+                )
+        );
+    }
+}

--- a/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
@@ -92,6 +92,7 @@ public class JiraMetricsServiceImpl implements JiraMetricsService {
         boolean connected = jiraApiClient.validateSpaceConnection(
                 integration.getJiraSpaceUrl(),
                 integration.getProjectKey(),
+                integration.getJiraEmail(),
                 integration.getApiKey());
 
         String message = connected

--- a/backend/src/main/resources/db/migration/V12__Create_Validation_Config_Table.sql
+++ b/backend/src/main/resources/db/migration/V12__Create_Validation_Config_Table.sql
@@ -1,0 +1,19 @@
+-- V12__Create_Validation_Config_Table.sql
+-- Singleton table for AI validation runtime configuration (Process 7 / Issue #298).
+-- id is always 1; enforced by PRIMARY KEY + CHECK constraint.
+-- excludedFilePatterns is stored as a comma-separated string (converted in Java).
+
+CREATE TABLE IF NOT EXISTS public.validation_config (
+    id                       BIGINT          PRIMARY KEY,
+    review_weight            INTEGER         NOT NULL DEFAULT 40,
+    implementation_weight    INTEGER         NOT NULL DEFAULT 60,
+    openai_model             VARCHAR(50)     NOT NULL DEFAULT 'gpt-4o',
+    max_diff_lines           INTEGER         NOT NULL DEFAULT 500,
+    excluded_file_patterns   TEXT            NOT NULL DEFAULT ''
+);
+
+-- Guarantee the singleton row is present with defaults.
+INSERT INTO public.validation_config (id, review_weight, implementation_weight,
+                                      openai_model, max_diff_lines, excluded_file_patterns)
+VALUES (1, 40, 60, 'gpt-4o', 500, '')
+ON CONFLICT (id) DO NOTHING;

--- a/backend/src/main/resources/db/migration/V12__Create_Validation_Config_Table.sql
+++ b/backend/src/main/resources/db/migration/V12__Create_Validation_Config_Table.sql
@@ -9,11 +9,11 @@ CREATE TABLE IF NOT EXISTS public.validation_config (
     implementation_weight    INTEGER         NOT NULL DEFAULT 60,
     openai_model             VARCHAR(50)     NOT NULL DEFAULT 'gpt-4o',
     max_diff_lines           INTEGER         NOT NULL DEFAULT 500,
-    excluded_file_patterns   TEXT            NOT NULL DEFAULT ''
+    excluded_file_patterns   TEXT            NOT NULL DEFAULT '{}'
 );
 
 -- Guarantee the singleton row is present with defaults.
 INSERT INTO public.validation_config (id, review_weight, implementation_weight,
                                       openai_model, max_diff_lines, excluded_file_patterns)
-VALUES (1, 40, 60, 'gpt-4o', 500, '')
+VALUES (1, 40, 60, 'gpt-4o', 500, '{}')
 ON CONFLICT (id) DO NOTHING;

--- a/backend/src/test/java/com/spms/backend/service/AiValidationConfigServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/AiValidationConfigServiceTest.java
@@ -1,0 +1,216 @@
+package com.spms.backend.service;
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config + validation_config singleton
+//   Affects: AiValidationConfigServiceImpl.java, ValidationConfig.java, ValidationConfigRepository.java
+//   Coordinate before editing: check with team
+
+import com.spms.backend.dto.request.ValidationConfigRequest;
+import com.spms.backend.dto.response.ValidationConfigResponse;
+import com.spms.backend.exception.BadRequestException;
+import com.spms.backend.model.ValidationConfig;
+import com.spms.backend.repository.ValidationConfigRepository;
+import com.spms.backend.service.impl.AiValidationConfigServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link AiValidationConfigServiceImpl}.
+ *
+ * <p>Spec: P7-AI-Validation-api.yaml §7.0 Configuration — Issue #298.</p>
+ *
+ * <p>Each test pins one acceptance criterion from the issue AC list.
+ * Structural assertions are used (field values, exception types) — no
+ * string-matching on human-readable messages per §9 of CONTRIBUTING.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class AiValidationConfigServiceTest {
+
+    @Mock
+    private ValidationConfigRepository configRepository;
+
+    @InjectMocks
+    private AiValidationConfigServiceImpl service;
+
+    /** Default singleton with sensible values (as inserted by V12 migration). */
+    private ValidationConfig defaultConfig;
+
+    @BeforeEach
+    void setUp() {
+        defaultConfig = new ValidationConfig();
+        defaultConfig.setId(1L);
+        defaultConfig.setReviewWeight(40);
+        defaultConfig.setImplementationWeight(60);
+        defaultConfig.setOpenaiModel("gpt-4o");
+        defaultConfig.setMaxDiffLines(500);
+        defaultConfig.setExcludedFilePatterns(Collections.emptyList());
+    }
+
+    // ── AC: GET returns current config ───────────────────────────────────
+
+    @Test
+    @DisplayName("getConfig: returns config with status=success and correct data fields")
+    void getConfig_returnsCurrentConfig() {
+        when(configRepository.findById(1L)).thenReturn(Optional.of(defaultConfig));
+
+        ValidationConfigResponse response = service.getConfig();
+
+        assertEquals("success", response.status());
+        assertNotNull(response.data());
+        assertEquals(40, response.data().reviewWeight());
+        assertEquals(60, response.data().implementationWeight());
+        assertEquals("gpt-4o", response.data().openaiModel());
+        assertEquals(500, response.data().maxDiffLines());
+        assertNotNull(response.data().excludedFilePatterns()); // never null
+        assertTrue(response.data().excludedFilePatterns().isEmpty());
+    }
+
+    // ── AC: Valid PUT → 200 with updated body ────────────────────────────
+
+    @Test
+    @DisplayName("updateConfig: valid request returns updated ValidationConfigResponse")
+    void updateConfig_validRequest_returnsUpdated() {
+        when(configRepository.findById(1L)).thenReturn(Optional.of(defaultConfig));
+        when(configRepository.save(any(ValidationConfig.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ValidationConfigRequest req = new ValidationConfigRequest(
+                30, 70, "gpt-4o-mini", 300, List.of("package-lock.json")
+        );
+
+        ValidationConfigResponse response = service.updateConfig(req);
+
+        assertEquals("success", response.status());
+        assertEquals(30, response.data().reviewWeight());
+        assertEquals(70, response.data().implementationWeight());
+        assertEquals("gpt-4o-mini", response.data().openaiModel());
+        assertEquals(300, response.data().maxDiffLines());
+        assertEquals(1, response.data().excludedFilePatterns().size());
+        assertEquals("package-lock.json", response.data().excludedFilePatterns().get(0));
+    }
+
+    // ── AC: reviewWeight + implementationWeight ≠ 100 → 400 INVALID_WEIGHTS ──
+
+    @Test
+    @DisplayName("updateConfig: weights sum != 100 → BadRequestException with INVALID_WEIGHTS code")
+    void updateConfig_invalidWeights_throwsBadRequest() {
+        ValidationConfigRequest req = new ValidationConfigRequest(
+                60, 60, null, null, null
+        );
+
+        BadRequestException ex = assertThrows(BadRequestException.class,
+                () -> service.updateConfig(req));
+        assertTrue(ex.getMessage().startsWith("INVALID_WEIGHTS"),
+                "Message should begin with errorCode INVALID_WEIGHTS but was: " + ex.getMessage());
+        // Repository must NOT be called — validation should short-circuit
+        verify(configRepository, never()).save(any());
+    }
+
+    // ── AC: maxDiffLines = 0 → 400 INVALID_MAX_DIFF_LINES ───────────────
+
+    @Test
+    @DisplayName("updateConfig: maxDiffLines=0 → BadRequestException with INVALID_MAX_DIFF_LINES code")
+    void updateConfig_maxDiffLinesZero_throwsBadRequest() {
+        ValidationConfigRequest req = new ValidationConfigRequest(
+                40, 60, null, 0, null
+        );
+
+        BadRequestException ex = assertThrows(BadRequestException.class,
+                () -> service.updateConfig(req));
+        assertTrue(ex.getMessage().startsWith("INVALID_MAX_DIFF_LINES"),
+                "Message should begin with INVALID_MAX_DIFF_LINES but was: " + ex.getMessage());
+        verify(configRepository, never()).save(any());
+    }
+
+    // ── AC: openaiModel not in whitelist → 400 INVALID_OPENAI_MODEL ─────
+
+    @Test
+    @DisplayName("updateConfig: openaiModel=gpt-3.5-fake → BadRequestException with INVALID_OPENAI_MODEL code")
+    void updateConfig_invalidModel_throwsBadRequest() {
+        ValidationConfigRequest req = new ValidationConfigRequest(
+                40, 60, "gpt-3.5-fake", null, null
+        );
+
+        BadRequestException ex = assertThrows(BadRequestException.class,
+                () -> service.updateConfig(req));
+        assertTrue(ex.getMessage().startsWith("INVALID_OPENAI_MODEL"),
+                "Message should begin with INVALID_OPENAI_MODEL but was: " + ex.getMessage());
+        verify(configRepository, never()).save(any());
+    }
+
+    // ── AC: excludedFilePatterns=[] → stored as empty, GET returns [] not null ──
+
+    @Test
+    @DisplayName("updateConfig: excludedFilePatterns=[] → response returns empty list, not null")
+    void updateConfig_emptyPatterns_returnsEmptyNotNull() {
+        when(configRepository.findById(1L)).thenReturn(Optional.of(defaultConfig));
+        when(configRepository.save(any(ValidationConfig.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ValidationConfigRequest req = new ValidationConfigRequest(
+                40, 60, null, null, Collections.emptyList()
+        );
+
+        ValidationConfigResponse response = service.updateConfig(req);
+
+        assertNotNull(response.data().excludedFilePatterns(),
+                "excludedFilePatterns must never be null");
+        assertTrue(response.data().excludedFilePatterns().isEmpty(),
+                "excludedFilePatterns should be an empty list, not null");
+    }
+
+    // ── AC: null excludedFilePatterns in request → existing value preserved ──
+
+    @Test
+    @DisplayName("updateConfig: null excludedFilePatterns in request → existing patterns preserved")
+    void updateConfig_nullPatterns_preservesExisting() {
+        defaultConfig.setExcludedFilePatterns(List.of("*.svg"));
+        when(configRepository.findById(1L)).thenReturn(Optional.of(defaultConfig));
+        when(configRepository.save(any(ValidationConfig.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ValidationConfigRequest req = new ValidationConfigRequest(
+                40, 60, null, null, null // null → keep existing
+        );
+
+        ValidationConfigResponse response = service.updateConfig(req);
+        assertEquals(List.of("*.svg"), response.data().excludedFilePatterns());
+    }
+
+    // ── All three allowed models pass validation ──────────────────────────
+
+    @Test
+    @DisplayName("updateConfig: all whitelisted openaiModels are accepted")
+    void updateConfig_allAllowedModels_succeed() {
+        List<String> allowed = List.of("gpt-4o", "gpt-4o-mini", "gpt-4-turbo");
+        when(configRepository.findById(1L)).thenReturn(Optional.of(defaultConfig));
+        when(configRepository.save(any(ValidationConfig.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        for (String model : allowed) {
+            ValidationConfigRequest req = new ValidationConfigRequest(40, 60, model, null, null);
+            assertDoesNotThrow(() -> service.updateConfig(req),
+                    "Model " + model + " should be accepted");
+        }
+    }
+
+    // ── maxDiffLines=1 is the minimum allowed ────────────────────────────
+
+    @Test
+    @DisplayName("updateConfig: maxDiffLines=1 is accepted (minimum valid value)")
+    void updateConfig_maxDiffLinesOne_isAccepted() {
+        when(configRepository.findById(1L)).thenReturn(Optional.of(defaultConfig));
+        when(configRepository.save(any(ValidationConfig.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ValidationConfigRequest req = new ValidationConfigRequest(40, 60, null, 1, null);
+        assertDoesNotThrow(() -> service.updateConfig(req));
+    }
+}

--- a/frontend/app/coordinator/ai-validation/config/page.tsx
+++ b/frontend/app/coordinator/ai-validation/config/page.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config frontend page
+//   Affects: lib/ai-validation-api.ts, P7-AI-Validation-api.yaml §7.0 Configuration
+//   Coordinate before editing: check with team
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  fetchValidationConfig,
+  updateValidationConfig,
+  ValidationConfigData,
+} from '@/lib/ai-validation-api';
+import { showToast } from '@/components/toast/ToastContext';
+
+// Allowed OpenAI models — must match the server-side whitelist exactly.
+const ALLOWED_MODELS = ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo'] as const;
+type AllowedModel = (typeof ALLOWED_MODELS)[number];
+
+interface FormState {
+  reviewWeight: string;
+  implementationWeight: string;
+  openaiModel: AllowedModel;
+  maxDiffLines: string;
+  excludedFilePatterns: string; // textarea: one pattern per line
+}
+
+function configDataToFormState(data: ValidationConfigData): FormState {
+  return {
+    reviewWeight: String(data.reviewWeight),
+    implementationWeight: String(data.implementationWeight),
+    openaiModel: (ALLOWED_MODELS.includes(data.openaiModel as AllowedModel)
+      ? data.openaiModel
+      : 'gpt-4o') as AllowedModel,
+    maxDiffLines: String(data.maxDiffLines),
+    excludedFilePatterns: (data.excludedFilePatterns ?? []).join('\n'),
+  };
+}
+
+export default function AiValidationConfigPage() {
+  const [form, setForm] = useState<FormState>({
+    reviewWeight: '40',
+    implementationWeight: '60',
+    openaiModel: 'gpt-4o',
+    maxDiffLines: '500',
+    excludedFilePatterns: '',
+  });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // ── Load config on mount ──────────────────────────────────────────────
+  const loadConfig = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const response = await fetchValidationConfig();
+      setForm(configDataToFormState(response.data));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to load configuration.';
+      setLoadError(msg);
+      showToast(msg, 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadConfig();
+  }, [loadConfig]);
+
+  // ── Derived: weight sum indicator ─────────────────────────────────────
+  const reviewWeightNum = parseInt(form.reviewWeight, 10) || 0;
+  const implWeightNum = parseInt(form.implementationWeight, 10) || 0;
+  const weightSum = reviewWeightNum + implWeightNum;
+  const weightsValid = weightSum === 100;
+
+  // ── Change handlers ───────────────────────────────────────────────────
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  }
+
+  // ── Save ──────────────────────────────────────────────────────────────
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    // Client-side guard (server will also validate)
+    if (!weightsValid) {
+      showToast('reviewWeight + implementationWeight must equal 100.', 'error');
+      return;
+    }
+    const maxLines = parseInt(form.maxDiffLines, 10);
+    if (form.maxDiffLines !== '' && maxLines < 1) {
+      showToast('maxDiffLines must be at least 1.', 'error');
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const patterns = form.excludedFilePatterns
+        .split('\n')
+        .map((p) => p.trim())
+        .filter((p) => p.length > 0);
+
+      const updated = await updateValidationConfig({
+        reviewWeight: reviewWeightNum,
+        implementationWeight: implWeightNum,
+        openaiModel: form.openaiModel,
+        maxDiffLines: maxLines,
+        excludedFilePatterns: patterns,
+      });
+
+      setForm(configDataToFormState(updated.data));
+      showToast('Configuration saved successfully.', 'success');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to save configuration.';
+      showToast(msg, 'error');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────
+  if (loading) {
+    return (
+      <div className="p-8 flex items-center justify-center min-h-[60vh]">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-10 h-10 border-4 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+          <p className="text-slate-400 text-sm">Loading configuration…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="p-8">
+        <div className="rounded-xl bg-red-900/20 border border-red-700/40 p-6 text-red-300 text-sm">
+          <p className="font-semibold mb-1">Failed to load configuration</p>
+          <p>{loadError}</p>
+          <button
+            onClick={loadConfig}
+            className="mt-4 px-4 py-2 rounded-lg bg-red-700 hover:bg-red-600 transition text-white text-sm"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto">
+      {/* ── Page header ── */}
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-white tracking-tight">
+          AI Validation Configuration
+        </h1>
+        <p className="mt-1 text-sm text-slate-400">
+          Adjust scoring weights, the OpenAI model, and diff filter rules.
+          Changes apply to <span className="text-indigo-400 font-medium">future runs only</span> — existing results are not recalculated.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} noValidate>
+        {/* ── Card ── */}
+        <div className="rounded-2xl bg-slate-800/60 border border-slate-700/50 backdrop-blur-sm divide-y divide-slate-700/40">
+
+          {/* ── Scoring weights ── */}
+          <section className="p-6">
+            <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+              Scoring Weights
+            </h2>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label
+                  htmlFor="reviewWeight"
+                  className="block text-xs font-medium text-slate-400 mb-1"
+                >
+                  Review Weight (%)
+                </label>
+                <input
+                  id="reviewWeight"
+                  name="reviewWeight"
+                  type="number"
+                  min={0}
+                  max={100}
+                  required
+                  value={form.reviewWeight}
+                  onChange={handleChange}
+                  className="w-full rounded-lg bg-slate-900/60 border border-slate-600 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/60 transition"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="implementationWeight"
+                  className="block text-xs font-medium text-slate-400 mb-1"
+                >
+                  Implementation Weight (%)
+                </label>
+                <input
+                  id="implementationWeight"
+                  name="implementationWeight"
+                  type="number"
+                  min={0}
+                  max={100}
+                  required
+                  value={form.implementationWeight}
+                  onChange={handleChange}
+                  className="w-full rounded-lg bg-slate-900/60 border border-slate-600 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/60 transition"
+                />
+              </div>
+            </div>
+
+            {/* Live weight-sum indicator */}
+            <div
+              className={`mt-3 flex items-center gap-2 text-sm font-medium transition-colors ${
+                weightsValid ? 'text-emerald-400' : 'text-red-400'
+              }`}
+            >
+              <span
+                className={`inline-block w-2 h-2 rounded-full ${
+                  weightsValid ? 'bg-emerald-400' : 'bg-red-400'
+                }`}
+              />
+              {weightsValid
+                ? 'Weights sum to 100 ✓'
+                : `Weights sum to ${weightSum} — must equal 100`}
+            </div>
+          </section>
+
+          {/* ── OpenAI model ── */}
+          <section className="p-6">
+            <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+              OpenAI Model
+            </h2>
+            <div>
+              <label
+                htmlFor="openaiModel"
+                className="block text-xs font-medium text-slate-400 mb-1"
+              >
+                Model
+              </label>
+              <select
+                id="openaiModel"
+                name="openaiModel"
+                value={form.openaiModel}
+                onChange={handleChange}
+                className="w-full rounded-lg bg-slate-900/60 border border-slate-600 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/60 transition"
+              >
+                {ALLOWED_MODELS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </section>
+
+          {/* ── Diff settings ── */}
+          <section className="p-6">
+            <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+              Diff Settings
+            </h2>
+            <div>
+              <label
+                htmlFor="maxDiffLines"
+                className="block text-xs font-medium text-slate-400 mb-1"
+              >
+                Max Diff Lines
+              </label>
+              <input
+                id="maxDiffLines"
+                name="maxDiffLines"
+                type="number"
+                min={1}
+                value={form.maxDiffLines}
+                onChange={handleChange}
+                className="w-full rounded-lg bg-slate-900/60 border border-slate-600 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500/60 transition"
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Maximum number of diff lines sent to OpenAI per PR. Excess is truncated.
+              </p>
+            </div>
+          </section>
+
+          {/* ── Excluded file patterns ── */}
+          <section className="p-6">
+            <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wider mb-4">
+              Excluded File Patterns
+            </h2>
+            <div>
+              <label
+                htmlFor="excludedFilePatterns"
+                className="block text-xs font-medium text-slate-400 mb-1"
+              >
+                Patterns (one per line)
+              </label>
+              <textarea
+                id="excludedFilePatterns"
+                name="excludedFilePatterns"
+                rows={5}
+                value={form.excludedFilePatterns}
+                onChange={handleChange}
+                placeholder="package-lock.json&#10;*.min.js&#10;*.svg"
+                className="w-full rounded-lg bg-slate-900/60 border border-slate-600 px-3 py-2 text-white text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500/60 transition resize-y"
+              />
+              <p className="mt-1 text-xs text-slate-500">
+                Leave empty to include all files. Supports glob patterns (e.g.{' '}
+                <code className="text-indigo-400">*.svg</code>).
+              </p>
+            </div>
+          </section>
+        </div>
+
+        {/* ── Actions ── */}
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={loadConfig}
+            disabled={loading || saving}
+            className="px-5 py-2.5 rounded-lg border border-slate-600 text-slate-300 text-sm hover:bg-slate-700 transition disabled:opacity-50"
+          >
+            Reset
+          </button>
+          <button
+            id="save-config-btn"
+            type="submit"
+            disabled={saving || !weightsValid}
+            className="px-6 py-2.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium transition disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {saving && (
+              <span className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+            )}
+            {saving ? 'Saving…' : 'Save Configuration'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/lib/ai-validation-api.ts
+++ b/frontend/lib/ai-validation-api.ts
@@ -1,0 +1,76 @@
+// TODO(parallel: #298, @you, 2026-05-05): GET/PUT /ai-validation/config frontend page
+//   Affects: app/coordinator/ai-validation/config/page.tsx
+//   Coordinate before editing: check with team
+
+import { API_BASE, buildHeaders, parseError } from "@/lib/api-utils";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+/** Spec: ValidationConfigResponse.data */
+export interface ValidationConfigData {
+  reviewWeight: number;
+  implementationWeight: number;
+  openaiModel: string;
+  maxDiffLines: number;
+  excludedFilePatterns: string[];
+}
+
+/** Spec: ValidationConfigResponse envelope */
+export interface ValidationConfigResponse {
+  status: string;
+  data: ValidationConfigData;
+}
+
+/** Spec: ValidationConfigRequest (required: reviewWeight, implementationWeight) */
+export interface ValidationConfigRequest {
+  reviewWeight: number;
+  implementationWeight: number;
+  openaiModel?: string;
+  maxDiffLines?: number;
+  excludedFilePatterns?: string[];
+}
+
+// ── API functions ──────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/ai-validation/config
+ * Coordinator only. Returns the current AI validation configuration.
+ */
+export async function fetchValidationConfig(): Promise<ValidationConfigResponse> {
+  const res = await fetch(`${API_BASE}/ai-validation/config`, {
+    headers: buildHeaders(),
+  });
+
+  if (!res.ok) {
+    const msg = await parseError(res);
+    throw new Error(msg);
+  }
+
+  return res.json();
+}
+
+/**
+ * PUT /api/v1/ai-validation/config
+ * Coordinator only. Updates and returns the new AI validation configuration.
+ *
+ * Business rules enforced server-side:
+ * - reviewWeight + implementationWeight must equal 100 → INVALID_WEIGHTS
+ * - maxDiffLines (if provided) must be ≥ 1 → INVALID_MAX_DIFF_LINES
+ * - openaiModel (if provided) must be one of gpt-4o, gpt-4o-mini, gpt-4-turbo → INVALID_OPENAI_MODEL
+ */
+export async function updateValidationConfig(
+  payload: ValidationConfigRequest
+): Promise<ValidationConfigResponse> {
+  const res = await fetch(`${API_BASE}/ai-validation/config`, {
+    method: "PUT",
+    headers: buildHeaders(),
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const msg = await parseError(res);
+    throw new Error(msg);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
### Summary

Implements Process 7 Configuration endpoints (`GET` and `PUT /ai-validation/config`)
plus the Coordinator-only admin form at `/coordinator/ai-validation/config`.

### Acceptance Criteria → Code Mapping

| AC | Backend | Frontend |
|----|---------|----------|
| `reviewWeight + implementationWeight ≠ 100` → 400 INVALID_WEIGHTS | `AiValidationConfigServiceImpl.validate()` | Client-side guard + live indicator |
| `maxDiffLines = 0` → 400 INVALID_MAX_DIFF_LINES | `AiValidationConfigServiceImpl.validate()` | — |
| `openaiModel = "gpt-3.5-fake"` → 400 INVALID_OPENAI_MODEL | `AiValidationConfigServiceImpl.validate()` (whitelist: gpt-4o, gpt-4o-mini, gpt-4-turbo) | `<select>` dropdown limits choices |
| `excludedFilePatterns = []` → stored as empty, GET returns `[]` never null | `StringListConverter` + entity null guards | — |
| Valid PUT → 200 with `ValidationConfigResponse` | Controller returns `configService.updateConfig()` | Form refreshes from response body |
| Advisor/Student → 403 | `requireCoordinator()` → `ForbiddenException` | Global interceptor shows toast |
| Config change → future runs only | Config is read at pipeline trigger time (no retroactive recalc) | Banner text states this |

### Contract Decisions

- **Spec already exists** — `P7-AI-Validation-api.yaml` §7.0 (lines 467–536). No `docs:` PR needed.
- **ErrorCode encoding** — Existing `ErrorResponse(error, message)` lacks an `errorCode` field.
  Rather than a breaking DTO change, error codes are prefixed in the `message` string
  (e.g. `"INVALID_WEIGHTS: reviewWeight + implementationWeight must equal 100."`).
- **Route** — `/coordinator/ai-validation/config` (not `/admin/`) to match existing frontend layout.

### Schema Changes (DDL)
added public.validation_config table

## Test
`mvn test -Dtest=AiValidationConfigServiceTest`


