### PR TITLE
fix: resolve notification center synchronization and update logic

### DIFF
--- a/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/JiraMetricsServiceImpl.java
@@ -92,6 +92,7 @@ public class JiraMetricsServiceImpl implements JiraMetricsService {
         boolean connected = jiraApiClient.validateSpaceConnection(
                 integration.getJiraSpaceUrl(),
                 integration.getProjectKey(),
+                integration.getJiraEmail(),
                 integration.getApiKey());
 
         String message = connected

--- a/backend/src/main/java/com/spms/backend/service/impl/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/NotificationServiceImpl.java
@@ -25,6 +25,7 @@ import com.spms.backend.service.NotificationService;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.slf4j.Logger;
@@ -42,18 +43,21 @@ public class NotificationServiceImpl implements NotificationService {
     private final GroupRepository groupRepository;
     private final ScheduleRepository scheduleRepository;
     private final MemberService memberService;
+    private final SimpMessagingTemplate messagingTemplate;
     private static final Logger log = LoggerFactory.getLogger(NotificationServiceImpl.class);
 
     public NotificationServiceImpl(NotificationRepository notificationRepository,
                                    UserRepository userRepository,
                                    GroupRepository groupRepository,
                                    ScheduleRepository scheduleRepository,
-                                   @Lazy MemberService memberService) {
+                                   @Lazy MemberService memberService,
+                                   SimpMessagingTemplate messagingTemplate) {
         this.notificationRepository = notificationRepository;
         this.userRepository = userRepository;
         this.groupRepository = groupRepository;
         this.scheduleRepository = scheduleRepository;
         this.memberService = memberService;
+        this.messagingTemplate = messagingTemplate;
     }
 
     @Override
@@ -118,7 +122,9 @@ public class NotificationServiceImpl implements NotificationService {
         notification.setFromUser(leader);
         notification.setToUser(professor);
 
-        return notificationRepository.save(notification).getId();
+        Notification saved = notificationRepository.save(notification);
+        pushWebSocket(professor.getUserId(), mapToDto(saved));
+        return saved.getId();
     }
 
     @Override
@@ -264,7 +270,8 @@ public class NotificationServiceImpl implements NotificationService {
             throw new BadRequestException("Invalid decision value! Only 'accept' or 'reject' are supported.");
         }
 
-        notificationRepository.save(notification);
+        Notification saved = notificationRepository.save(notification);
+        pushWebSocket(userId, mapToDto(saved));
     }
 
     @Override
@@ -285,7 +292,8 @@ public class NotificationServiceImpl implements NotificationService {
             notification.setFromUser(actor);
             notification.setToUser(recipient);
 
-            notificationRepository.save(notification);
+            Notification saved = notificationRepository.save(notification);
+            pushWebSocket(recipient.getUserId(), mapToDto(saved));
         }
     }
 
@@ -300,8 +308,9 @@ public class NotificationServiceImpl implements NotificationService {
         n.setMessage(message + (metadata != null ? " | " + metadata : ""));
         n.setStatus(NotificationStatus.PENDING);
         n.setToUser(recipient);
-        notificationRepository.save(n);
-        return n;
+        Notification saved = notificationRepository.save(n);
+        pushWebSocket(recipient.getUserId(), mapToDto(saved));
+        return saved;
     }
 
     @Override
@@ -331,6 +340,17 @@ public class NotificationServiceImpl implements NotificationService {
                 notif.getCreatedAt()
         );
     }
+    private void pushWebSocket(Long toUserId, NotificationDto dto) {
+        try {
+            messagingTemplate.convertAndSendToUser(
+                    toUserId.toString(),
+                    "/queue/notifications",
+                    dto);
+        } catch (Exception e) {
+            log.warn("[WebSocket] Push failed for userId={}: {}", toUserId, e.getMessage());
+        }
+    }
+
     @Override
     public void sendMembershipInvite(Long toUserId, Long groupId, String groupName) {
         log.info("Membership invite notification sent to user {} for group {}", toUserId, groupName);

--- a/frontend/components/NotificationItem.tsx
+++ b/frontend/components/NotificationItem.tsx
@@ -62,6 +62,7 @@ function StatusBadge({ status }: { status: Notification["status"] }) {
         accepted: "bg-green-500/20 text-green-300",
         rejected: "bg-red-500/20 text-red-300",
         cleared: "bg-white/10 text-gray-400",
+        revoked: "bg-orange-500/20 text-orange-300",
     };
     return (
         <span className={`rounded-full px-2 py-0.5 text-xs font-medium capitalize ${classes[status] ?? "bg-white/10 text-gray-400"}`}>

--- a/frontend/components/NotificationProvider.tsx
+++ b/frontend/components/NotificationProvider.tsx
@@ -13,7 +13,7 @@ import { useRouter } from "next/navigation";
 import { Client, IMessage } from "@stomp/stompjs";
 import SockJS from "sockjs-client";
 import {
-    fetchMyCommitteeNotifications,
+    fetchNotifications,
     respondNotification,
     clearNotificationApi,
 } from "@/lib/notifications-api";
@@ -25,7 +25,7 @@ import {
 import { API_BASE } from "@/lib/api-utils";
 
 // ------------------------------------------------------------------ Types
-const ENABLE_NOTIFICATIONS = false;
+const ENABLE_NOTIFICATIONS = true;
 type NotificationContextType = {
     notifications: Notification[];
     unreadOrPendingCount: number;
@@ -92,9 +92,9 @@ export function NotificationProvider({ children }: { children: ReactNode }) {
         async function load() {
             try {
                 setLoading(true);
-                const data = await fetchMyCommitteeNotifications();
+                const page = await fetchNotifications(0, 100);
                 if (cancelled) return;
-                const mapped = data.map(mapApiNotification);
+                const mapped = page.content.map(mapApiNotification);
                 mapped.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
                 setNotifications(mapped);
             } catch {

--- a/frontend/lib/notification-types.ts
+++ b/frontend/lib/notification-types.ts
@@ -16,7 +16,8 @@ export type NotificationStatus =
     | "pending"
     | "accepted"
     | "rejected"
-    | "cleared";
+    | "cleared"
+    | "revoked";
 
 export type Notification = {
     id: number;


### PR DESCRIPTION
 ## Summary                                                                                                                                                                        
                                                
  Notification system was completely broken. Frontend notifications were disabled and backend wasn't pushing updates via WebSocket. This PR enables the entire notification         
  pipeline:                                                                                                                                                                                                                                                                                                                                                             
  - **Enabled notifications** in frontend (was disabled with `ENABLE_NOTIFICATIONS = false`)                                                                                        
  - **Added WebSocket push** to NotificationServiceImpl for all notification types
  - **Fixed API endpoint** inconsistency in NotificationProvider
  - **Added "revoked" status** support to match backend (was missing from frontend types)

  ## Changes

  ### Backend (`NotificationServiceImpl.java`)
  - Injected `SimpMessagingTemplate` for WebSocket messaging
  - Added `pushWebSocket()` helper method to send notifications via `/user/queue/notifications`
  - WebSocket push added to:
    - `requestAdvisor()` - advisor request notifications
    - `respondToNotification()` - accept/reject feedback
    - `sendGroupDisbandedNotification()` - group disbanded alerts
    - `createSystemAlert()` - system alerts

  ### Frontend
  - **NotificationProvider.tsx**:
    - Set `ENABLE_NOTIFICATIONS = true` (line 28)
    - Fixed endpoint from `fetchMyCommitteeNotifications()` to `fetchNotifications()` (line 16, 95)
    - Now fetches from `/api/v1/notifications` instead of `/api/v1/committees/notifications`

  - **notification-types.ts**:
    - Added `"revoked"` to `NotificationStatus` type (line 19)
    - Matches backend's `NotificationStatus.REVOKED` enum value

  - **NotificationItem.tsx**:
    - Added styling for `"revoked"` status in `StatusBadge` component (line 65)
    - Orange color for revoked notifications

  ## Issues Fixed

  1. **Notifications not displaying**: `ENABLE_NOTIFICATIONS` was hardcoded to `false`
  2. **No real-time updates**: Backend wasn't sending notifications via WebSocket
  3. **Wrong endpoint**: Frontend was fetching committee-only notifications instead of all notifications
  4. **Status type mismatch**: Frontend didn't recognize `"revoked"` status from backend

  ## Test Plan

  - [ ] Create an advisor request → verify notification appears in real-time on recipient's screen
  - [ ] Accept/reject a notification → verify status updates immediately
  - [ ] Check browser DevTools → WebSocket connection should show messages being received
  - [ ] Create a system alert → verify it displays with warning icon
  - [ ] Disband a group → verify all members receive notification
  - [ ] Test with multiple users → verify each receives only their notifications

  ## Technical Details

  - WebSocket endpoint: `/ws` (SockJS with fallback)
  - Push destination: `/user/{userId}/queue/notifications`
  - Notification status flow: `PENDING` → `ACCEPTED`/`REJECTED`/`REVOKED`/`CLEARED`
  - All status values converted to lowercase when serialized to JSON
