### PR TITLE
feat: add sprint results & issue details endpoints with RBAC (Resolves #296)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/AiValidationController.java
+++ b/backend/src/main/java/com/spms/backend/controller/AiValidationController.java
@@ -2,11 +2,14 @@ package com.spms.backend.controller;
 
 import com.spms.backend.dto.request.TriggerValidationRequest;
 import com.spms.backend.dto.response.ErrorResponse;
+import com.spms.backend.dto.response.IssueValidationDetailResponse;
 import com.spms.backend.dto.response.JobStatusResponse;
+import com.spms.backend.dto.response.SprintValidationResultsResponse;
 import com.spms.backend.dto.response.TriggerValidationResponse;
 import com.spms.backend.exception.P7ApiException;
 import com.spms.backend.model.ValidationJob;
 import com.spms.backend.service.AiValidationJobService;
+import com.spms.backend.service.ValidationResultReadService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,9 +17,12 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/ai-validation")
 public class AiValidationController {
     private final AiValidationJobService jobService;
+    private final ValidationResultReadService resultReadService;
 
-    public AiValidationController(AiValidationJobService jobService) {
+    public AiValidationController(AiValidationJobService jobService,
+                                  ValidationResultReadService resultReadService) {
         this.jobService = jobService;
+        this.resultReadService = resultReadService;
     }
 
     @PostMapping("/sprints/{sprintId}/trigger")
@@ -134,6 +140,51 @@ public class AiValidationController {
                             job.getStartedAt()
                     )
             ));
+        } catch (P7ApiException ex) {
+            return ResponseEntity.status(ex.getStatus())
+                    .body(new ErrorResponse(ex.getErrorCode(), ex.getMessage()));
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  7.6  —  Sprint-Level Results (Issue #296)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @GetMapping("/sprints/{sprintId}/results")
+    public ResponseEntity<?> getSprintResults(
+            @PathVariable Long sprintId,
+            @RequestParam(required = false) Long teamId,
+            @RequestAttribute("jwt_role") Object role,
+            @RequestAttribute("jwt_userId") Object userId
+    ) {
+        try {
+            String userRole = role != null ? role.toString() : null;
+            Long uid = userId != null ? Long.valueOf(userId.toString()) : null;
+            SprintValidationResultsResponse response = resultReadService.getSprintResults(
+                    sprintId, teamId, userRole, uid);
+            return ResponseEntity.ok(response);
+        } catch (P7ApiException ex) {
+            return ResponseEntity.status(ex.getStatus())
+                    .body(new ErrorResponse(ex.getErrorCode(), ex.getMessage()));
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  7.6  —  Issue-Level Detail (Issue #296)
+    // ═══════════════════════════════════════════════════════════════════
+
+    @GetMapping("/issues/{issueKey}/details")
+    public ResponseEntity<?> getIssueDetails(
+            @PathVariable String issueKey,
+            @RequestAttribute("jwt_role") Object role,
+            @RequestAttribute("jwt_userId") Object userId
+    ) {
+        try {
+            String userRole = role != null ? role.toString() : null;
+            Long uid = userId != null ? Long.valueOf(userId.toString()) : null;
+            IssueValidationDetailResponse response = resultReadService.getIssueDetails(
+                    issueKey, userRole, uid);
+            return ResponseEntity.ok(response);
         } catch (P7ApiException ex) {
             return ResponseEntity.status(ex.getStatus())
                     .body(new ErrorResponse(ex.getErrorCode(), ex.getMessage()));

--- a/backend/src/main/java/com/spms/backend/dto/response/IssueValidationDetailResponse.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/IssueValidationDetailResponse.java
@@ -1,0 +1,67 @@
+package com.spms.backend.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Response DTO for {@code GET /api/v1/ai-validation/issues/{issueKey}/details}.
+ *
+ * <p>Spec shape (P7-AI-Validation-api.yaml §IssueValidationDetailResponse):
+ * <pre>
+ * {
+ *   "status": "success",
+ *   "data": {
+ *     "issueKey": "PROJ-123",
+ *     "issueDescription": "...",
+ *     "prNumber": 42,
+ *     "prUrl": "https://github.com/...",
+ *     "evaluatedAt": "...",
+ *     "reviewVerification": { ... },
+ *     "implementationValidation": { ... }
+ *   }
+ * }
+ * </pre>
+ * </p>
+ *
+ * <p>DFD: 7.4 AI Review Verification + 7.5 AI Implementation Validation — Issue #296.</p>
+ */
+public record IssueValidationDetailResponse(
+        String status,
+        IssueDetailData data
+) {
+
+    public record IssueDetailData(
+            String issueKey,
+            String issueDescription,
+            Integer prNumber,
+            String prUrl,
+            Instant evaluatedAt,
+            ReviewVerification reviewVerification,
+            ImplementationValidation implementationValidation
+    ) {}
+
+    public record ReviewVerification(
+            Double score,
+            Boolean hasReview,
+            String reviewQuality,
+            Integer reviewerCount,
+            Boolean hasChangeRequests,
+            Boolean hasSubstantiveComments,
+            String aiFeedback
+    ) {}
+
+    public record ImplementationValidation(
+            Double score,
+            Boolean isValid,
+            List<CoverageArea> coverageAreas,
+            List<String> missingRequirements,
+            String aiFeedback,
+            Integer filesAnalyzed,
+            Boolean diffTruncated
+    ) {}
+
+    public record CoverageArea(
+            String requirement,
+            Boolean covered
+    ) {}
+}

--- a/backend/src/main/java/com/spms/backend/dto/response/SprintValidationResultsResponse.java
+++ b/backend/src/main/java/com/spms/backend/dto/response/SprintValidationResultsResponse.java
@@ -1,0 +1,55 @@
+package com.spms.backend.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Response DTO for {@code GET /api/v1/ai-validation/sprints/{sprintId}/results}.
+ *
+ * <p>Spec shape (P7-AI-Validation-api.yaml §SprintValidationResultsResponse):
+ * <pre>
+ * {
+ *   "status": "success",
+ *   "data": {
+ *     "sprintId": "...",
+ *     "evaluatedAt": "...",
+ *     "teams": [ { TeamValidationResult } ]
+ *   }
+ * }
+ * </pre>
+ * </p>
+ *
+ * <p>DFD: 7.6 Store Validation Results (read side) — Issue #296.</p>
+ */
+public record SprintValidationResultsResponse(
+        String status,
+        SprintResultsData data
+) {
+
+    public record SprintResultsData(
+            Long sprintId,
+            Instant evaluatedAt,
+            List<TeamResult> teams
+    ) {}
+
+    public record TeamResult(
+            Long teamId,
+            String teamName,
+            double overallSprintScore,
+            int issueCount,
+            List<IssueSummary> issues
+    ) {}
+
+    public record IssueSummary(
+            String issueKey,
+            String issueTitle,
+            String assignee,
+            Integer prNumber,
+            Boolean prMerged,
+            Double reviewVerificationScore,
+            String reviewQuality,
+            Double implementationMatchScore,
+            Double compositeScore,
+            String status
+    ) {}
+}

--- a/backend/src/main/java/com/spms/backend/model/IssueValidationResult.java
+++ b/backend/src/main/java/com/spms/backend/model/IssueValidationResult.java
@@ -24,6 +24,12 @@ public class IssueValidationResult {
     @Column(name = "issue_title")
     private String issueTitle;
 
+    @Column(name = "issue_description", columnDefinition = "TEXT")
+    private String issueDescription;
+
+    @Column(name = "has_review")
+    private Boolean hasReview;
+
     @Column(name = "assignee")
     private String assignee;
 
@@ -144,4 +150,8 @@ public class IssueValidationResult {
     public void setSprintId(Long sprintId) { this.sprintId = sprintId; }
     public Long getTeamId() { return teamId; }
     public void setTeamId(Long teamId) { this.teamId = teamId; }
+    public String getIssueDescription() { return issueDescription; }
+    public void setIssueDescription(String issueDescription) { this.issueDescription = issueDescription; }
+    public Boolean getHasReview() { return hasReview; }
+    public void setHasReview(Boolean hasReview) { this.hasReview = hasReview; }
 }

--- a/backend/src/main/java/com/spms/backend/repository/IssueValidationResultRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/IssueValidationResultRepository.java
@@ -12,4 +12,8 @@ public interface IssueValidationResultRepository extends JpaRepository<IssueVali
     List<IssueValidationResult> findByJob_JobId(Long jobId);
     Optional<IssueValidationResult> findByJob_JobIdAndIssueKey(Long jobId, String issueKey);
     List<IssueValidationResult> findByJob_JobIdAndValidationStatus(Long jobId, String validationStatus);
+
+    List<IssueValidationResult> findBySprintId(Long sprintId);
+    List<IssueValidationResult> findBySprintIdAndTeamId(Long sprintId, Long teamId);
+    Optional<IssueValidationResult> findTopByIssueKeyOrderByEvaluatedAtDesc(String issueKey);
 }

--- a/backend/src/main/java/com/spms/backend/service/ValidationResultReadService.java
+++ b/backend/src/main/java/com/spms/backend/service/ValidationResultReadService.java
@@ -1,0 +1,344 @@
+package com.spms.backend.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spms.backend.dto.response.IssueValidationDetailResponse;
+import com.spms.backend.dto.response.IssueValidationDetailResponse.*;
+import com.spms.backend.dto.response.SprintValidationResultsResponse;
+import com.spms.backend.dto.response.SprintValidationResultsResponse.*;
+import com.spms.backend.exception.P7ApiException;
+import com.spms.backend.model.Group;
+import com.spms.backend.model.IssueValidationResult;
+import com.spms.backend.model.ValidationConfig;
+import com.spms.backend.repository.GroupRepository;
+import com.spms.backend.repository.IssueValidationResultRepository;
+import com.spms.backend.repository.SprintRepository;
+import com.spms.backend.repository.ValidationConfigRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Read service for AI validation results — powers the Advisor Dashboard.
+ *
+ * <p>DFD: 7.6 Store Validation Results (read side) — Issue #296.</p>
+ *
+ * <p>Responsibilities:
+ * <ul>
+ *   <li>Sprint-level aggregation with per-team grouping</li>
+ *   <li>Per-issue detail drill-down</li>
+ *   <li>RBAC: Advisor sees only advisee teams; Coordinator sees all</li>
+ *   <li>Composite score recalculation at query time from validation_config weights</li>
+ * </ul></p>
+ */
+@Service
+public class ValidationResultReadService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ValidationResultReadService.class);
+
+    private static final String STATUS_VALIDATED = "VALIDATED";
+
+    private final IssueValidationResultRepository resultRepository;
+    private final ValidationConfigRepository configRepository;
+    private final SprintRepository sprintRepository;
+    private final GroupRepository groupRepository;
+    private final ObjectMapper objectMapper;
+
+    public ValidationResultReadService(
+            IssueValidationResultRepository resultRepository,
+            ValidationConfigRepository configRepository,
+            SprintRepository sprintRepository,
+            GroupRepository groupRepository,
+            ObjectMapper objectMapper) {
+        this.resultRepository = resultRepository;
+        this.configRepository = configRepository;
+        this.sprintRepository = sprintRepository;
+        this.groupRepository = groupRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * GET /ai-validation/sprints/{sprintId}/results
+     *
+     * <p>Returns aggregated validation results grouped by team, with RBAC filtering.</p>
+     */
+    @Transactional(readOnly = true)
+    public SprintValidationResultsResponse getSprintResults(Long sprintId, Long teamId,
+                                                             String role, Long userId) {
+        enforceP7Access(role);
+
+        sprintRepository.findById(sprintId)
+                .orElseThrow(() -> new P7ApiException(HttpStatus.NOT_FOUND,
+                        "SPRINT_NOT_FOUND", "Sprint not found."));
+
+        Set<Long> allowedTeamIds = resolveAllowedTeamIds(role, userId, teamId);
+
+        List<IssueValidationResult> results;
+        if (teamId != null) {
+            results = resultRepository.findBySprintIdAndTeamId(sprintId, teamId);
+        } else {
+            results = resultRepository.findBySprintId(sprintId);
+        }
+
+        if (results.isEmpty()) {
+            throw new P7ApiException(HttpStatus.NOT_FOUND,
+                    "SPRINT_HAS_NO_RESULTS", "No validation results exist for this sprint.");
+        }
+
+        // Filter by RBAC-allowed teams (for advisors)
+        if (allowedTeamIds != null) {
+            results = results.stream()
+                    .filter(r -> r.getTeamId() != null && allowedTeamIds.contains(r.getTeamId()))
+                    .collect(Collectors.toList());
+
+            if (results.isEmpty()) {
+                throw new P7ApiException(HttpStatus.NOT_FOUND,
+                        "SPRINT_HAS_NO_RESULTS", "No validation results exist for your teams in this sprint.");
+            }
+        }
+
+        ValidationConfig config = loadConfig();
+
+        Instant latestEvaluatedAt = results.stream()
+                .map(IssueValidationResult::getEvaluatedAt)
+                .filter(Objects::nonNull)
+                .max(Instant::compareTo)
+                .orElse(null);
+
+        // Group by teamId
+        Map<Long, List<IssueValidationResult>> byTeam = results.stream()
+                .filter(r -> r.getTeamId() != null)
+                .collect(Collectors.groupingBy(IssueValidationResult::getTeamId));
+
+        // Build team name lookup
+        Set<Long> teamIds = byTeam.keySet();
+        Map<Long, String> teamNames = groupRepository.findAllById(teamIds).stream()
+                .collect(Collectors.toMap(Group::getId, Group::getGroupName));
+
+        List<TeamResult> teams = new ArrayList<>();
+        for (Map.Entry<Long, List<IssueValidationResult>> entry : byTeam.entrySet()) {
+            Long tid = entry.getKey();
+            List<IssueValidationResult> teamResults = entry.getValue();
+
+            List<IssueSummary> issueSummaries = teamResults.stream()
+                    .map(r -> toIssueSummary(r, config))
+                    .collect(Collectors.toList());
+
+            double overallScore = teamResults.stream()
+                    .filter(r -> STATUS_VALIDATED.equals(r.getValidationStatus()))
+                    .mapToDouble(r -> computeComposite(r, config))
+                    .average()
+                    .orElse(0.0);
+
+            // Round to 1 decimal for clean display
+            overallScore = BigDecimal.valueOf(overallScore)
+                    .setScale(1, RoundingMode.HALF_UP)
+                    .doubleValue();
+
+            teams.add(new TeamResult(
+                    tid,
+                    teamNames.getOrDefault(tid, "Unknown Team"),
+                    overallScore,
+                    teamResults.size(),
+                    issueSummaries
+            ));
+        }
+
+        logger.info("Sprint results retrieved. sprintId={}, teamCount={}, totalIssues={}",
+                sprintId, teams.size(), results.size());
+
+        return new SprintValidationResultsResponse(
+                "success",
+                new SprintResultsData(sprintId, latestEvaluatedAt, teams)
+        );
+    }
+
+    /**
+     * GET /ai-validation/issues/{issueKey}/details
+     *
+     * <p>Returns the full AI analysis detail for a specific issue, with RBAC.</p>
+     */
+    @Transactional(readOnly = true)
+    public IssueValidationDetailResponse getIssueDetails(String issueKey, String role, Long userId) {
+        enforceP7Access(role);
+
+        IssueValidationResult result = resultRepository.findTopByIssueKeyOrderByEvaluatedAtDesc(issueKey)
+                .orElseThrow(() -> new P7ApiException(HttpStatus.NOT_FOUND,
+                        "ISSUE_NOT_VALIDATED", "Issue not yet validated."));
+
+        // RBAC check on the issue's team
+        if ("advisor".equalsIgnoreCase(role)) {
+            Set<Long> advisorTeamIds = getAdvisorTeamIds(userId);
+            if (result.getTeamId() == null || !advisorTeamIds.contains(result.getTeamId())) {
+                throw new P7ApiException(HttpStatus.FORBIDDEN,
+                        "FORBIDDEN_TEAM_ACCESS", "Advisor is not authorized for this team.");
+            }
+        }
+
+        logger.info("Issue details retrieved. issueKey={}, resultId={}", issueKey, result.getId());
+
+        return new IssueValidationDetailResponse(
+                "success",
+                toIssueDetailData(result)
+        );
+    }
+
+    // ── RBAC helpers ─────────────────────────────────────────────────────
+
+    private void enforceP7Access(String role) {
+        if (role == null || "student".equalsIgnoreCase(role)) {
+            throw new P7ApiException(HttpStatus.FORBIDDEN,
+                    "FORBIDDEN", "Caller role is not allowed.");
+        }
+        if (!"coordinator".equalsIgnoreCase(role) && !"advisor".equalsIgnoreCase(role)) {
+            throw new P7ApiException(HttpStatus.FORBIDDEN,
+                    "FORBIDDEN", "Caller role is not allowed.");
+        }
+    }
+
+    /**
+     * Resolves the set of team IDs the caller is allowed to see.
+     *
+     * @return null if coordinator (no filter), or a Set of allowed IDs for advisors
+     */
+    private Set<Long> resolveAllowedTeamIds(String role, Long userId, Long requestedTeamId) {
+        if ("coordinator".equalsIgnoreCase(role)) {
+            return null; // coordinator sees all
+        }
+
+        // Advisor
+        Set<Long> advisorTeamIds = getAdvisorTeamIds(userId);
+
+        if (requestedTeamId != null && !advisorTeamIds.contains(requestedTeamId)) {
+            throw new P7ApiException(HttpStatus.FORBIDDEN,
+                    "FORBIDDEN_TEAM_ACCESS", "Advisor is not authorized for this team.");
+        }
+
+        return advisorTeamIds;
+    }
+
+    private Set<Long> getAdvisorTeamIds(Long userId) {
+        return groupRepository.findByAdvisorId(userId).stream()
+                .map(Group::getId)
+                .collect(Collectors.toSet());
+    }
+
+    // ── Composite score ─────────────────────────────────────────────────
+
+    private double computeComposite(IssueValidationResult r, ValidationConfig config) {
+        BigDecimal rScore = r.getReviewScore() != null ? r.getReviewScore() : BigDecimal.ZERO;
+        BigDecimal iScore = r.getImplScore() != null ? r.getImplScore() : BigDecimal.ZERO;
+        return rScore.multiply(BigDecimal.valueOf(config.getReviewWeight()))
+                .add(iScore.multiply(BigDecimal.valueOf(config.getImplementationWeight())))
+                .divide(BigDecimal.valueOf(100), 2, RoundingMode.HALF_UP)
+                .doubleValue();
+    }
+
+    // ── DTO mapping ─────────────────────────────────────────────────────
+
+    private IssueSummary toIssueSummary(IssueValidationResult r, ValidationConfig config) {
+        Double compositeScore = null;
+        Double reviewScore = null;
+        Double implScore = null;
+
+        if (STATUS_VALIDATED.equals(r.getValidationStatus())) {
+            compositeScore = computeComposite(r, config);
+            reviewScore = r.getReviewScore() != null ? r.getReviewScore().doubleValue() : null;
+            implScore = r.getImplScore() != null ? r.getImplScore().doubleValue() : null;
+        }
+
+        return new IssueSummary(
+                r.getIssueKey(),
+                r.getIssueTitle(),
+                r.getAssignee(),
+                r.getPrNumber() != null ? r.getPrNumber().intValue() : null,
+                r.getPrMerged(),
+                reviewScore,
+                r.getReviewQuality(),
+                implScore,
+                compositeScore,
+                r.getValidationStatus()
+        );
+    }
+
+    private IssueDetailData toIssueDetailData(IssueValidationResult r) {
+        return new IssueDetailData(
+                r.getIssueKey(),
+                r.getIssueDescription(),
+                r.getPrNumber() != null ? r.getPrNumber().intValue() : null,
+                r.getPrUrl(),
+                r.getEvaluatedAt(),
+                toReviewVerification(r),
+                toImplementationValidation(r)
+        );
+    }
+
+    private ReviewVerification toReviewVerification(IssueValidationResult r) {
+        return new ReviewVerification(
+                r.getReviewScore() != null ? r.getReviewScore().doubleValue() : null,
+                r.getHasReview(),
+                r.getReviewQuality(),
+                r.getReviewerCount(),
+                r.getHasChangeRequests(),
+                r.getHasSubstantiveComments(),
+                r.getReviewAiFeedback()
+        );
+    }
+
+    private ImplementationValidation toImplementationValidation(IssueValidationResult r) {
+        return new ImplementationValidation(
+                r.getImplScore() != null ? r.getImplScore().doubleValue() : null,
+                r.getImplIsValid(),
+                parseCoverageAreas(r.getImplCoverageAreas()),
+                parseMissingRequirements(r.getImplMissingRequirements()),
+                r.getImplAiFeedback(),
+                r.getFilesAnalyzed(),
+                r.getDiffTruncated()
+        );
+    }
+
+    private List<CoverageArea> parseCoverageAreas(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            List<Map<String, Object>> raw = objectMapper.readValue(json,
+                    new TypeReference<List<Map<String, Object>>>() {});
+            return raw.stream()
+                    .map(m -> new CoverageArea(
+                            (String) m.get("requirement"),
+                            m.get("covered") instanceof Boolean b ? b : null
+                    ))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.warn("Failed to parse coverageAreas JSON (length={})", json.length());
+            return Collections.emptyList();
+        }
+    }
+
+    private List<String> parseMissingRequirements(String json) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyList();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            logger.warn("Failed to parse missingRequirements JSON (length={})", json.length());
+            return Collections.emptyList();
+        }
+    }
+
+    private ValidationConfig loadConfig() {
+        return configRepository.findById(1L)
+                .orElseThrow(() -> new IllegalStateException(
+                        "validation_config singleton row (id=1) is missing — check V12 migration."));
+    }
+}

--- a/backend/src/main/resources/db/migration/V15__Add_Issue_Description_Has_Review_To_Validation_Results.sql
+++ b/backend/src/main/resources/db/migration/V15__Add_Issue_Description_Has_Review_To_Validation_Results.sql
@@ -1,0 +1,3 @@
+ALTER TABLE issue_validation_results
+    ADD COLUMN IF NOT EXISTS issue_description TEXT,
+    ADD COLUMN IF NOT EXISTS has_review BOOLEAN;

--- a/backend/src/test/java/com/spms/backend/service/ValidationResultReadServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/ValidationResultReadServiceTest.java
@@ -1,0 +1,498 @@
+package com.spms.backend.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spms.backend.dto.response.IssueValidationDetailResponse;
+import com.spms.backend.dto.response.SprintValidationResultsResponse;
+import com.spms.backend.exception.P7ApiException;
+import com.spms.backend.model.Group;
+import com.spms.backend.model.IssueValidationResult;
+import com.spms.backend.model.User;
+import com.spms.backend.model.ValidationConfig;
+import com.spms.backend.model.Sprint;
+import com.spms.backend.repository.GroupRepository;
+import com.spms.backend.repository.IssueValidationResultRepository;
+import com.spms.backend.repository.SprintRepository;
+import com.spms.backend.repository.ValidationConfigRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link ValidationResultReadService} — Issue #296.
+ *
+ * <p>Covers all acceptance criteria: RBAC filtering, composite score
+ * recalculation at query time, 404 for missing data, and response shape.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class ValidationResultReadServiceTest {
+
+    @Mock
+    private IssueValidationResultRepository resultRepository;
+
+    @Mock
+    private ValidationConfigRepository configRepository;
+
+    @Mock
+    private SprintRepository sprintRepository;
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private ValidationResultReadService service;
+
+    private ValidationConfig config;
+    private Sprint sprint;
+
+    @BeforeEach
+    void setUp() {
+        config = new ValidationConfig();
+        config.setId(1L);
+        config.setReviewWeight(40);
+        config.setImplementationWeight(60);
+        config.setOpenaiModel("gpt-4o");
+        config.setMaxDiffLines(500);
+        config.setExcludedFilePatterns(Collections.emptyList());
+
+        sprint = new Sprint();
+        sprint.setId(1L);
+        sprint.setSprintName("Sprint 1");
+    }
+
+    // ── Test data factories ─────────────────────────────────────────────
+
+    private Group createTeam(Long id, String name, Long advisorUserId) {
+        Group g = new Group();
+        g.setId(id);
+        g.setGroupName(name);
+        if (advisorUserId != null) {
+            User advisor = new User();
+            advisor.setUserId(advisorUserId);
+            g.setAdvisor(advisor);
+        }
+        return g;
+    }
+
+    private IssueValidationResult createResult(Long sprintId, Long teamId, String issueKey,
+                                                BigDecimal reviewScore, BigDecimal implScore,
+                                                String status) {
+        IssueValidationResult r = new IssueValidationResult();
+        r.setId(1L);
+        r.setSprintId(sprintId);
+        r.setTeamId(teamId);
+        r.setIssueKey(issueKey);
+        r.setIssueTitle("Test issue: " + issueKey);
+        r.setAssignee("student@example.com");
+        r.setPrNumber(42L);
+        r.setPrMerged(true);
+        r.setReviewScore(reviewScore);
+        r.setReviewQuality("THOROUGH");
+        r.setReviewerCount(2);
+        r.setHasChangeRequests(true);
+        r.setHasSubstantiveComments(true);
+        r.setReviewAiFeedback("Good review process.");
+        r.setImplScore(implScore);
+        r.setImplIsValid(true);
+        r.setImplAiFeedback("Implementation matches requirements.");
+        r.setFilesAnalyzed(4);
+        r.setDiffTruncated(false);
+        r.setValidationStatus(status);
+        r.setEvaluatedAt(Instant.now());
+        return r;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Sprint Results
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("GET /sprints/{sprintId}/results")
+    class SprintResults {
+
+        @Test
+        @DisplayName("AC7: Composite score arithmetic — review=90, impl=80, weights 40/60 → 84.0")
+        void compositeScoreArithmetic() {
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+
+            IssueValidationResult result = createResult(1L, 10L, "PROJ-123",
+                    new BigDecimal("90.00"), new BigDecimal("80.00"), "VALIDATED");
+
+            when(resultRepository.findBySprintId(1L)).thenReturn(List.of(result));
+            when(groupRepository.findAllById(any())).thenReturn(
+                    List.of(createTeam(10L, "Alpha Team", null)));
+
+            SprintValidationResultsResponse response = service.getSprintResults(
+                    1L, null, "coordinator", 100L);
+
+            assertThat(response.status()).isEqualTo("success");
+            assertThat(response.data().teams()).hasSize(1);
+
+            var team = response.data().teams().get(0);
+            assertThat(team.overallSprintScore()).isEqualTo(84.0);
+
+            var issue = team.issues().get(0);
+            assertThat(issue.compositeScore()).isEqualTo(84.0);
+            assertThat(issue.reviewVerificationScore()).isEqualTo(90.0);
+            assertThat(issue.implementationMatchScore()).isEqualTo(80.0);
+        }
+
+        @Test
+        @DisplayName("AC1: Advisor querying own team → 200 with that team's results only")
+        void advisorOwnTeam() {
+            Long advisorUserId = 50L;
+            Long ownTeamId = 10L;
+            Long otherTeamId = 20L;
+
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+            when(groupRepository.findByAdvisorId(advisorUserId)).thenReturn(
+                    List.of(createTeam(ownTeamId, "My Team", advisorUserId)));
+
+            IssueValidationResult ownResult = createResult(1L, ownTeamId, "PROJ-1",
+                    new BigDecimal("85.00"), new BigDecimal("75.00"), "VALIDATED");
+            IssueValidationResult otherResult = createResult(1L, otherTeamId, "PROJ-2",
+                    new BigDecimal("70.00"), new BigDecimal("60.00"), "VALIDATED");
+
+            when(resultRepository.findBySprintId(1L)).thenReturn(List.of(ownResult, otherResult));
+            when(groupRepository.findAllById(any())).thenReturn(
+                    List.of(createTeam(ownTeamId, "My Team", advisorUserId)));
+
+            SprintValidationResultsResponse response = service.getSprintResults(
+                    1L, null, "advisor", advisorUserId);
+
+            assertThat(response.data().teams()).hasSize(1);
+            assertThat(response.data().teams().get(0).teamId()).isEqualTo(ownTeamId);
+        }
+
+        @Test
+        @DisplayName("AC2: Advisor querying a non-advisee teamId → 403 FORBIDDEN_TEAM_ACCESS")
+        void advisorNonAdviseeTeam() {
+            Long advisorUserId = 50L;
+            Long ownTeamId = 10L;
+            Long foreignTeamId = 99L;
+
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(groupRepository.findByAdvisorId(advisorUserId)).thenReturn(
+                    List.of(createTeam(ownTeamId, "My Team", advisorUserId)));
+
+            assertThatThrownBy(() -> service.getSprintResults(1L, foreignTeamId, "advisor", advisorUserId))
+                    .isInstanceOf(P7ApiException.class)
+                    .satisfies(ex -> {
+                        P7ApiException p7 = (P7ApiException) ex;
+                        assertThat(p7.getErrorCode()).isEqualTo("FORBIDDEN_TEAM_ACCESS");
+                        assertThat(p7.getStatus().value()).isEqualTo(403);
+                    });
+        }
+
+        @Test
+        @DisplayName("AC4: Coordinator → 200 with all teams; teamId filter narrows correctly")
+        void coordinatorAllTeams() {
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+
+            IssueValidationResult r1 = createResult(1L, 10L, "PROJ-1",
+                    new BigDecimal("90.00"), new BigDecimal("80.00"), "VALIDATED");
+            IssueValidationResult r2 = createResult(1L, 20L, "PROJ-2",
+                    new BigDecimal("70.00"), new BigDecimal("60.00"), "VALIDATED");
+
+            when(resultRepository.findBySprintId(1L)).thenReturn(List.of(r1, r2));
+            when(groupRepository.findAllById(any())).thenReturn(List.of(
+                    createTeam(10L, "Team A", null),
+                    createTeam(20L, "Team B", null)));
+
+            SprintValidationResultsResponse response = service.getSprintResults(
+                    1L, null, "coordinator", 100L);
+
+            assertThat(response.data().teams()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("AC4: Coordinator teamId filter narrows to single team")
+        void coordinatorTeamIdFilter() {
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+
+            IssueValidationResult r1 = createResult(1L, 10L, "PROJ-1",
+                    new BigDecimal("90.00"), new BigDecimal("80.00"), "VALIDATED");
+
+            when(resultRepository.findBySprintIdAndTeamId(1L, 10L)).thenReturn(List.of(r1));
+            when(groupRepository.findAllById(any())).thenReturn(
+                    List.of(createTeam(10L, "Team A", null)));
+
+            SprintValidationResultsResponse response = service.getSprintResults(
+                    1L, 10L, "coordinator", 100L);
+
+            assertThat(response.data().teams()).hasSize(1);
+            assertThat(response.data().teams().get(0).teamId()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("AC5: Sprint with no validation runs yet → 404 SPRINT_HAS_NO_RESULTS")
+        void sprintNoResults() {
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(resultRepository.findBySprintId(1L)).thenReturn(Collections.emptyList());
+
+            assertThatThrownBy(() -> service.getSprintResults(1L, null, "coordinator", 100L))
+                    .isInstanceOf(P7ApiException.class)
+                    .satisfies(ex -> {
+                        P7ApiException p7 = (P7ApiException) ex;
+                        assertThat(p7.getErrorCode()).isEqualTo("SPRINT_HAS_NO_RESULTS");
+                        assertThat(p7.getStatus().value()).isEqualTo(404);
+                    });
+        }
+
+        @Test
+        @DisplayName("Sprint not found → 404 SPRINT_NOT_FOUND")
+        void sprintNotFound() {
+            when(sprintRepository.findById(999L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getSprintResults(999L, null, "coordinator", 100L))
+                    .isInstanceOf(P7ApiException.class)
+                    .satisfies(ex -> {
+                        P7ApiException p7 = (P7ApiException) ex;
+                        assertThat(p7.getErrorCode()).isEqualTo("SPRINT_NOT_FOUND");
+                        assertThat(p7.getStatus().value()).isEqualTo(404);
+                    });
+        }
+
+        @Test
+        @DisplayName("Student role → 403 FORBIDDEN")
+        void studentForbidden() {
+            assertThatThrownBy(() -> service.getSprintResults(1L, null, "student", 100L))
+                    .isInstanceOf(P7ApiException.class)
+                    .satisfies(ex -> {
+                        P7ApiException p7 = (P7ApiException) ex;
+                        assertThat(p7.getErrorCode()).isEqualTo("FORBIDDEN");
+                        assertThat(p7.getStatus().value()).isEqualTo(403);
+                    });
+        }
+
+        @Test
+        @DisplayName("AC8: SKIPPED and FAILED issues present with correct status")
+        void skippedAndFailedPresent() {
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+
+            IssueValidationResult validated = createResult(1L, 10L, "PROJ-1",
+                    new BigDecimal("90.00"), new BigDecimal("80.00"), "VALIDATED");
+            IssueValidationResult skipped = createResult(1L, 10L, "PROJ-2",
+                    null, null, "SKIPPED");
+            IssueValidationResult failed = createResult(1L, 10L, "PROJ-3",
+                    null, null, "FAILED");
+
+            when(resultRepository.findBySprintId(1L)).thenReturn(List.of(validated, skipped, failed));
+            when(groupRepository.findAllById(any())).thenReturn(
+                    List.of(createTeam(10L, "Team A", null)));
+
+            SprintValidationResultsResponse response = service.getSprintResults(
+                    1L, null, "coordinator", 100L);
+
+            var issues = response.data().teams().get(0).issues();
+            assertThat(issues).hasSize(3);
+            assertThat(issues).extracting("status")
+                    .containsExactlyInAnyOrder("VALIDATED", "SKIPPED", "FAILED");
+
+            // SKIPPED and FAILED should have null scores
+            var skippedIssue = issues.stream()
+                    .filter(i -> "SKIPPED".equals(i.status())).findFirst().orElseThrow();
+            assertThat(skippedIssue.compositeScore()).isNull();
+            assertThat(skippedIssue.reviewVerificationScore()).isNull();
+
+            // VALIDATED should have scores
+            var validatedIssue = issues.stream()
+                    .filter(i -> "VALIDATED".equals(i.status())).findFirst().orElseThrow();
+            assertThat(validatedIssue.compositeScore()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("AC7: Overall sprint score averages only VALIDATED issues")
+        void overallScoreAveragesValidatedOnly() {
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+
+            // review=90, impl=80, weights 40/60 → composite=84.0
+            IssueValidationResult v1 = createResult(1L, 10L, "PROJ-1",
+                    new BigDecimal("90.00"), new BigDecimal("80.00"), "VALIDATED");
+            // review=70, impl=60, weights 40/60 → composite=64.0
+            IssueValidationResult v2 = createResult(1L, 10L, "PROJ-2",
+                    new BigDecimal("70.00"), new BigDecimal("60.00"), "VALIDATED");
+            // SKIPPED — should not affect average
+            IssueValidationResult sk = createResult(1L, 10L, "PROJ-3",
+                    null, null, "SKIPPED");
+
+            when(resultRepository.findBySprintId(1L)).thenReturn(List.of(v1, v2, sk));
+            when(groupRepository.findAllById(any())).thenReturn(
+                    List.of(createTeam(10L, "Team A", null)));
+
+            SprintValidationResultsResponse response = service.getSprintResults(
+                    1L, null, "coordinator", 100L);
+
+            // Average of 84.0 and 64.0 = 74.0
+            assertThat(response.data().teams().get(0).overallSprintScore()).isEqualTo(74.0);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //  Issue Details
+    // ═══════════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("GET /issues/{issueKey}/details")
+    class IssueDetails {
+
+        @Test
+        @DisplayName("AC6: Issue not yet validated → 404 ISSUE_NOT_VALIDATED")
+        void issueNotValidated() {
+            when(resultRepository.findTopByIssueKeyOrderByEvaluatedAtDesc("PROJ-999"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getIssueDetails("PROJ-999", "coordinator", 100L))
+                    .isInstanceOf(P7ApiException.class)
+                    .satisfies(ex -> {
+                        P7ApiException p7 = (P7ApiException) ex;
+                        assertThat(p7.getErrorCode()).isEqualTo("ISSUE_NOT_VALIDATED");
+                        assertThat(p7.getStatus().value()).isEqualTo(404);
+                    });
+        }
+
+        @Test
+        @DisplayName("AC3: Advisor opening a non-advisee issue's details → 403")
+        void advisorNonAdviseeIssue() {
+            Long advisorUserId = 50L;
+            Long ownTeamId = 10L;
+            Long foreignTeamId = 99L;
+
+            IssueValidationResult result = createResult(1L, foreignTeamId, "PROJ-123",
+                    new BigDecimal("90.00"), new BigDecimal("80.00"), "VALIDATED");
+
+            when(resultRepository.findTopByIssueKeyOrderByEvaluatedAtDesc("PROJ-123"))
+                    .thenReturn(Optional.of(result));
+            when(groupRepository.findByAdvisorId(advisorUserId)).thenReturn(
+                    List.of(createTeam(ownTeamId, "My Team", advisorUserId)));
+
+            assertThatThrownBy(() -> service.getIssueDetails("PROJ-123", "advisor", advisorUserId))
+                    .isInstanceOf(P7ApiException.class)
+                    .satisfies(ex -> {
+                        P7ApiException p7 = (P7ApiException) ex;
+                        assertThat(p7.getErrorCode()).isEqualTo("FORBIDDEN_TEAM_ACCESS");
+                        assertThat(p7.getStatus().value()).isEqualTo(403);
+                    });
+        }
+
+        @Test
+        @DisplayName("Coordinator can view any issue's details → 200")
+        void coordinatorCanViewAny() {
+            IssueValidationResult result = createResult(1L, 10L, "PROJ-123",
+                    new BigDecimal("90.00"), new BigDecimal("80.00"), "VALIDATED");
+            result.setIssueDescription("Implement user login flow.");
+            result.setPrUrl("https://github.com/org/repo/pull/42");
+
+            when(resultRepository.findTopByIssueKeyOrderByEvaluatedAtDesc("PROJ-123"))
+                    .thenReturn(Optional.of(result));
+
+            IssueValidationDetailResponse response = service.getIssueDetails(
+                    "PROJ-123", "coordinator", 100L);
+
+            assertThat(response.status()).isEqualTo("success");
+            assertThat(response.data().issueKey()).isEqualTo("PROJ-123");
+            assertThat(response.data().issueDescription()).isEqualTo("Implement user login flow.");
+            assertThat(response.data().prNumber()).isEqualTo(42);
+            assertThat(response.data().prUrl()).isEqualTo("https://github.com/org/repo/pull/42");
+            assertThat(response.data().reviewVerification()).isNotNull();
+            assertThat(response.data().reviewVerification().score()).isEqualTo(90.0);
+            assertThat(response.data().reviewVerification().reviewQuality()).isEqualTo("THOROUGH");
+            assertThat(response.data().implementationValidation()).isNotNull();
+            assertThat(response.data().implementationValidation().score()).isEqualTo(80.0);
+        }
+
+        @Test
+        @DisplayName("Advisor can view own team issue details → 200")
+        void advisorOwnTeamIssue() {
+            Long advisorUserId = 50L;
+            Long ownTeamId = 10L;
+
+            IssueValidationResult result = createResult(1L, ownTeamId, "PROJ-123",
+                    new BigDecimal("85.00"), new BigDecimal("75.00"), "VALIDATED");
+
+            when(resultRepository.findTopByIssueKeyOrderByEvaluatedAtDesc("PROJ-123"))
+                    .thenReturn(Optional.of(result));
+            when(groupRepository.findByAdvisorId(advisorUserId)).thenReturn(
+                    List.of(createTeam(ownTeamId, "My Team", advisorUserId)));
+
+            IssueValidationDetailResponse response = service.getIssueDetails(
+                    "PROJ-123", "advisor", advisorUserId);
+
+            assertThat(response.status()).isEqualTo("success");
+            assertThat(response.data().issueKey()).isEqualTo("PROJ-123");
+        }
+
+        @Test
+        @DisplayName("Student role → 403 FORBIDDEN")
+        void studentForbidden() {
+            assertThatThrownBy(() -> service.getIssueDetails("PROJ-123", "student", 100L))
+                    .isInstanceOf(P7ApiException.class)
+                    .satisfies(ex -> {
+                        P7ApiException p7 = (P7ApiException) ex;
+                        assertThat(p7.getErrorCode()).isEqualTo("FORBIDDEN");
+                        assertThat(p7.getStatus().value()).isEqualTo(403);
+                    });
+        }
+
+        @Test
+        @DisplayName("AC9: Response payload matches spec shape (reviewVerification + implementationValidation)")
+        void responseShapeMatchesSpec() {
+            IssueValidationResult result = createResult(1L, 10L, "PROJ-123",
+                    new BigDecimal("90.00"), new BigDecimal("80.00"), "VALIDATED");
+            result.setHasReview(true);
+            result.setImplCoverageAreas("[{\"requirement\":\"Login endpoint\",\"covered\":true}]");
+            result.setImplMissingRequirements("[\"Session management not implemented\"]");
+
+            when(resultRepository.findTopByIssueKeyOrderByEvaluatedAtDesc("PROJ-123"))
+                    .thenReturn(Optional.of(result));
+
+            IssueValidationDetailResponse response = service.getIssueDetails(
+                    "PROJ-123", "coordinator", 100L);
+
+            // Review verification
+            var rv = response.data().reviewVerification();
+            assertThat(rv.score()).isEqualTo(90.0);
+            assertThat(rv.hasReview()).isTrue();
+            assertThat(rv.reviewQuality()).isEqualTo("THOROUGH");
+            assertThat(rv.reviewerCount()).isEqualTo(2);
+            assertThat(rv.hasChangeRequests()).isTrue();
+            assertThat(rv.hasSubstantiveComments()).isTrue();
+            assertThat(rv.aiFeedback()).isNotNull();
+
+            // Implementation validation
+            var iv = response.data().implementationValidation();
+            assertThat(iv.score()).isEqualTo(80.0);
+            assertThat(iv.isValid()).isTrue();
+            assertThat(iv.coverageAreas()).hasSize(1);
+            assertThat(iv.coverageAreas().get(0).requirement()).isEqualTo("Login endpoint");
+            assertThat(iv.coverageAreas().get(0).covered()).isTrue();
+            assertThat(iv.missingRequirements()).containsExactly("Session management not implemented");
+            assertThat(iv.filesAnalyzed()).isEqualTo(4);
+            assertThat(iv.diffTruncated()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the two read-side endpoints that power the **Advisor Dashboard** (Process 7, DFD 7.6 — Store Validation Results, read side):

- `GET /api/v1/ai-validation/sprints/{sprintId}/results` — Sprint-level aggregated results grouped by team
- `GET /api/v1/ai-validation/issues/{issueKey}/details` — Per-issue AI analysis drill-down

Both endpoints enforce **RBAC**: Advisor sees only advisee teams (via `groups.advisor_id`), Coordinator sees all, Student gets 403.

## AC → Change Mapping

| # | Acceptance Criterion | Implementation |
|---|---|---|
| AC1 | Advisor querying own team → 200 with that team's results only | `ValidationResultReadService.resolveAllowedTeamIds()` filters by `GroupRepository.findByAdvisorId()` |
| AC2 | Advisor querying a non-advisee teamId → 403 | `resolveAllowedTeamIds()` throws `FORBIDDEN_TEAM_ACCESS` |
| AC3 | Advisor opening a non-advisee issue's details → 403 | `getIssueDetails()` checks `result.getTeamId()` against advisor's teams |
| AC4 | Coordinator → 200 with all teams; teamId filter narrows correctly | Coordinator bypasses team filter; `teamId` query param routes to `findBySprintIdAndTeamId()` |
| AC5 | Sprint with no validation runs yet → 404 | `SPRINT_HAS_NO_RESULTS` when result list is empty |
| AC6 | Issue not yet validated → 404 | `ISSUE_NOT_VALIDATED` when `findTopByIssueKeyOrderByEvaluatedAtDesc()` returns empty |
| AC7 | Composite score arithmetic (review=90, impl=80, weights 40/60 → 84.0) | `computeComposite()` recalculates at query time from `validation_config` weights |
| AC8 | SKIPPED and FAILED issues present with correct status | All statuses included in response; SKIPPED/FAILED have null scores |
| AC9 | Response payloads validate against OpenAPI schema | `SprintValidationResultsResponse` and `IssueValidationDetailResponse` match spec field-by-field |

## Design Rationale

- **Composite score recalculated at query time** from `validation_config` weights — not using stored `composite_score` column. Config changes (e.g. 40/60 → 50/50) apply immediately to all dashboard views without reprocessing.
- **Dedicated `ValidationResultReadService`** (SRP) — separate from `AiValidationJobService` which handles job lifecycle. Different dependencies (needs `ValidationConfigRepository` + `GroupRepository`).
- **Denormalized `sprint_id`/`team_id` columns** (V14) used for queries — already indexed by `idx_ivr_sprint_team_issue`. Avoids costly join through `validation_jobs`.
- **Advisor scoping** via existing `groups.advisor_id` FK + `GroupRepository.findByAdvisorId()` — no separate join table needed.

## Infra Changes

| Type | Detail |
|---|---|
| DB Schema | V15 migration: `ALTER TABLE issue_validation_results ADD COLUMN issue_description TEXT, ADD COLUMN has_review BOOLEAN` |
| Dependencies | None added |
| Config | No `application.yml` changes |

## Known Limitations

- **Pipeline (#297) does not populate `issueTitle`, `issueDescription`, `hasReview`** when writing `IssueValidationResult`. These fields will be `null` in the dashboard until a follow-up pipeline update. The read service handles NULLs gracefully.
  - `ValidationPipelineOrchestratorImpl.java:148-149` — `setIssueTitle()` never called
  - `ValidationPipelineOrchestratorImpl.java:222` — `issueDescription` hardcoded to `"Issue: " + issueKey`, not stored

## Follow-Up Issues

- [x] Pipeline: populate `issueTitle`, `issueDescription`, `hasReview` in `IssueValidationResult` during subprocess 7.4/7.5

## Test Plan


16 unit tests covering all 9 ACs + role-based edge cases (student forbidden, sprint not found, coordinator detail access, advisor own-team detail).

## PR Author Checklist (§10)

- [x] Branch is rebased onto current `main` (Section 8).
- [x] Every changed DTO field, response shape, and status code matches the spec (Section 5).
- [x] Spec gaps were resolved with the relevant team lead before coding (Section 6).
- [x] Side-effects listed in the spec are implemented and tested (Section 9).
- [x] No `TODO`/`FIXME` admitting partial implementation remains in shipped code (Section 6).
- [x] My own `TODO(parallel: ...)` markers are removed (Section 7).
- [x] Tests use shared factories and structural assertions (Section 9).
