### PR TITLE
feat: add Process 7 sprint results dashboard (Resolves #300)

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/AiValidationController.java
+++ b/backend/src/main/java/com/spms/backend/controller/AiValidationController.java
@@ -204,7 +204,7 @@ public class AiValidationController {
         if ("student".equalsIgnoreCase(userRole)) {
             throw new P7ApiException(org.springframework.http.HttpStatus.FORBIDDEN, "FORBIDDEN", "Caller role is not allowed.");
         }
-        if ("advisor".equalsIgnoreCase(userRole)) {
+        if (isAdvisorRole(userRole)) {
             if (job.getTeam() == null || job.getTeam().getAdvisor() == null || userIdObj == null) {
                 throw new P7ApiException(org.springframework.http.HttpStatus.FORBIDDEN, "FORBIDDEN_TEAM_ACCESS", "Advisor is not authorized for this team.");
             }
@@ -215,6 +215,10 @@ public class AiValidationController {
             return;
         }
         throw new P7ApiException(org.springframework.http.HttpStatus.FORBIDDEN, "FORBIDDEN", "Caller role is not allowed.");
+    }
+
+    private boolean isAdvisorRole(String role) {
+        return "advisor".equalsIgnoreCase(role) || "professor".equalsIgnoreCase(role);
     }
 
     private String messageForStep(ValidationJob job) {

--- a/backend/src/main/java/com/spms/backend/service/ValidationResultReadService.java
+++ b/backend/src/main/java/com/spms/backend/service/ValidationResultReadService.java
@@ -175,7 +175,7 @@ public class ValidationResultReadService {
                         "ISSUE_NOT_VALIDATED", "Issue not yet validated."));
 
         // RBAC check on the issue's team
-        if ("advisor".equalsIgnoreCase(role)) {
+        if (isAdvisorRole(role)) {
             Set<Long> advisorTeamIds = getAdvisorTeamIds(userId);
             if (result.getTeamId() == null || !advisorTeamIds.contains(result.getTeamId())) {
                 throw new P7ApiException(HttpStatus.FORBIDDEN,
@@ -198,7 +198,7 @@ public class ValidationResultReadService {
             throw new P7ApiException(HttpStatus.FORBIDDEN,
                     "FORBIDDEN", "Caller role is not allowed.");
         }
-        if (!"coordinator".equalsIgnoreCase(role) && !"advisor".equalsIgnoreCase(role)) {
+        if (!"coordinator".equalsIgnoreCase(role) && !isAdvisorRole(role)) {
             throw new P7ApiException(HttpStatus.FORBIDDEN,
                     "FORBIDDEN", "Caller role is not allowed.");
         }
@@ -229,6 +229,10 @@ public class ValidationResultReadService {
         return groupRepository.findByAdvisorId(userId).stream()
                 .map(Group::getId)
                 .collect(Collectors.toSet());
+    }
+
+    private boolean isAdvisorRole(String role) {
+        return "advisor".equalsIgnoreCase(role) || "professor".equalsIgnoreCase(role);
     }
 
     // ── Composite score ─────────────────────────────────────────────────

--- a/backend/src/test/java/com/spms/backend/service/ValidationResultReadServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/ValidationResultReadServiceTest.java
@@ -185,6 +185,31 @@ class ValidationResultReadServiceTest {
         }
 
         @Test
+        @DisplayName("Professor role is treated as advisor for own advisee teams")
+        void professorRoleOwnTeam() {
+            Long advisorUserId = 50L;
+            Long ownTeamId = 10L;
+
+            when(sprintRepository.findById(1L)).thenReturn(Optional.of(sprint));
+            when(configRepository.findById(1L)).thenReturn(Optional.of(config));
+            when(groupRepository.findByAdvisorId(advisorUserId)).thenReturn(
+                    List.of(createTeam(ownTeamId, "My Team", advisorUserId)));
+
+            IssueValidationResult ownResult = createResult(1L, ownTeamId, "PROJ-1",
+                    new BigDecimal("85.00"), new BigDecimal("75.00"), "VALIDATED");
+
+            when(resultRepository.findBySprintId(1L)).thenReturn(List.of(ownResult));
+            when(groupRepository.findAllById(any())).thenReturn(
+                    List.of(createTeam(ownTeamId, "My Team", advisorUserId)));
+
+            SprintValidationResultsResponse response = service.getSprintResults(
+                    1L, null, "professor", advisorUserId);
+
+            assertThat(response.data().teams()).hasSize(1);
+            assertThat(response.data().teams().get(0).teamId()).isEqualTo(ownTeamId);
+        }
+
+        @Test
         @DisplayName("AC2: Advisor querying a non-advisee teamId → 403 FORBIDDEN_TEAM_ACCESS")
         void advisorNonAdviseeTeam() {
             Long advisorUserId = 50L;
@@ -441,6 +466,27 @@ class ValidationResultReadServiceTest {
 
             IssueValidationDetailResponse response = service.getIssueDetails(
                     "PROJ-123", "advisor", advisorUserId);
+
+            assertThat(response.status()).isEqualTo("success");
+            assertThat(response.data().issueKey()).isEqualTo("PROJ-123");
+        }
+
+        @Test
+        @DisplayName("Professor role can view own team issue details")
+        void professorOwnTeamIssue() {
+            Long advisorUserId = 50L;
+            Long ownTeamId = 10L;
+
+            IssueValidationResult result = createResult(1L, ownTeamId, "PROJ-123",
+                    new BigDecimal("85.00"), new BigDecimal("75.00"), "VALIDATED");
+
+            when(resultRepository.findTopByIssueKeyOrderByEvaluatedAtDesc("PROJ-123"))
+                    .thenReturn(Optional.of(result));
+            when(groupRepository.findByAdvisorId(advisorUserId)).thenReturn(
+                    List.of(createTeam(ownTeamId, "My Team", advisorUserId)));
+
+            IssueValidationDetailResponse response = service.getIssueDetails(
+                    "PROJ-123", "professor", advisorUserId);
 
             assertThat(response.status()).isEqualTo("success");
             assertThat(response.data().issueKey()).isEqualTo("PROJ-123");

--- a/frontend/app/coordinator/ai-validation/config/page.tsx
+++ b/frontend/app/coordinator/ai-validation/config/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useState, useCallback } from 'react';
+import Link from 'next/link';
 import { useAuthGuard } from '@/hooks/useAuthGuard';
 import Sidebar from '@/components/Sidebar';
 import {
@@ -62,6 +63,12 @@ function AccessDenied() {
         </div>
         <h1 className="text-lg font-semibold text-white">Access Restricted</h1>
         <p className="text-sm text-gray-500">Only Coordinators can access this page.</p>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-white/5 border border-white/10 text-sm text-gray-300 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          Back to Dashboard
+        </Link>
       </div>
     </div>
   );
@@ -186,11 +193,22 @@ function ConfigForm() {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-white/8 rounded-2xl p-12 flex items-center justify-center">
-        <svg className="w-5 h-5 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
-          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-        </svg>
+      <div className="space-y-5" aria-label="Loading validation configuration">
+        {[0, 1, 2].map((section) => (
+          <div key={section} className="bg-gray-900 border border-white/8 rounded-2xl overflow-hidden animate-pulse">
+            <div className="px-6 py-4 border-b border-white/5 flex items-center gap-3">
+              <div className="w-8 h-8 rounded-lg bg-gray-800" />
+              <div className="space-y-2">
+                <div className="h-3 w-32 bg-gray-800 rounded" />
+                <div className="h-2 w-48 bg-gray-800 rounded" />
+              </div>
+            </div>
+            <div className="p-6 space-y-3">
+              <div className="h-10 bg-gray-800 rounded-xl" />
+              <div className="h-10 bg-gray-800 rounded-xl" />
+            </div>
+          </div>
+        ))}
       </div>
     );
   }

--- a/frontend/app/coordinator/ai-validation/sprints/[sprintId]/page.tsx
+++ b/frontend/app/coordinator/ai-validation/sprints/[sprintId]/page.tsx
@@ -1,20 +1,28 @@
-'use client';
+"use client";
 
-import { useEffect, useState, useCallback } from 'react';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import { useAuthGuard } from '@/hooks/useAuthGuard';
-import Sidebar from '@/components/Sidebar';
-import JobProgress from '@/components/ai-validation/JobProgress';
-import TriggerModal from '@/components/ai-validation/TriggerModal';
-import { getActiveJobForSprint } from '@/lib/ai-validation-api';
-import { fetchGroups } from '@/lib/groups-api';
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { AlertTriangle, Loader2, Play, RefreshCw, ShieldAlert } from "lucide-react";
+import { useAuthGuard } from "@/hooks/useAuthGuard";
+import { getUser } from "@/lib/auth";
+import Sidebar from "@/components/Sidebar";
+import JobProgress from "@/components/ai-validation/JobProgress";
+import TriggerModal from "@/components/ai-validation/TriggerModal";
+import SprintResultsDashboard from "@/components/ai-validation/SprintResultsDashboard";
+import {
+  fetchSprintValidationResults,
+  getActiveJobForSprint,
+  SprintValidationResultsData,
+} from "@/lib/ai-validation-api";
+import { fetchGroups } from "@/lib/groups-api";
 
-type PageState = 'loading' | 'trigger' | 'progress' | 'not_found' | 'forbidden';
+type PageState = "loading" | "results" | "progress" | "empty" | "forbidden" | "error";
 
 export default function SprintAiValidationPage() {
-  const authStatus = useAuthGuard('coordinator');
-  if (authStatus === 'loading') return <FullSpinner />;
-  if (authStatus === 'denied') return <AccessDenied />;
+  const authStatus = useAuthGuard(["coordinator", "professor"]);
+  if (authStatus === "loading") return <FullSpinner />;
+  if (authStatus === "denied") return <AccessDenied />;
   return <SprintPageLayout />;
 }
 
@@ -23,66 +31,101 @@ function SprintPageLayout() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const sprintId = params.sprintId;
+  const user = getUser();
+  const isCoordinator = user?.role === "coordinator";
 
-  const [pageState, setPageState] = useState<PageState>('loading');
+  const [pageState, setPageState] = useState<PageState>("loading");
+  const [results, setResults] = useState<SprintValidationResultsData | null>(null);
+  const [allTeams, setAllTeams] = useState<{ id: string; name: string }[]>([]);
+  const [teamsForTrigger, setTeamsForTrigger] = useState<{ id: string; name: string }[]>([]);
+  const [selectedTeamId, setSelectedTeamId] = useState("");
   const [jobId, setJobId] = useState<number | null>(() => {
-    const raw = searchParams.get('jobId');
+    const raw = searchParams.get("jobId");
     return raw ? Number(raw) : null;
   });
   const [showModal, setShowModal] = useState(false);
-  const [teams, setTeams] = useState<{ id: string; name: string }[]>([]);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchGroups(0, 200).then((page) => {
-      setTeams(page.content.map((g) => ({ id: String(g.id), name: g.groupName })));
-    }).catch(() => { /* teams dropdown stays empty, text input fallback */ });
-  }, []);
+    if (!isCoordinator) return;
+    fetchGroups(0, 200)
+      .then((page) => setTeamsForTrigger(page.content.map((g) => ({ id: String(g.id), name: g.groupName }))))
+      .catch(() => setTeamsForTrigger([]));
+  }, [isCoordinator]);
 
   const syncJobIdToUrl = useCallback(
     (id: number | null) => {
       const next = new URLSearchParams(searchParams.toString());
       if (id === null) {
-        next.delete('jobId');
+        next.delete("jobId");
       } else {
-        next.set('jobId', String(id));
+        next.set("jobId", String(id));
       }
-      router.replace(`?${next.toString()}`, { scroll: false });
+      const query = next.toString();
+      router.replace(`/coordinator/ai-validation/sprints/${sprintId}${query ? `?${query}` : ""}`, { scroll: false });
     },
-    [router, searchParams]
+    [router, searchParams, sprintId]
   );
 
-  const loadActiveJob = useCallback(async () => {
-    setPageState('loading');
+  const loadResults = useCallback(
+    async (teamId?: string, preserveTeamOptions = false) => {
+      setPageState("loading");
+      setErrorMessage(null);
+      try {
+        const response = await fetchSprintValidationResults(sprintId, teamId);
+        setResults(response.data);
+        if (!teamId || !preserveTeamOptions || allTeams.length === 0) {
+          setAllTeams(response.data.teams.map((team) => ({ id: String(team.teamId), name: team.teamName })));
+        }
+        setPageState(response.data.teams.length > 0 ? "results" : "empty");
+      } catch (err: unknown) {
+        const error = err as Error & { httpStatus?: number; errorCode?: string };
+        if (error.httpStatus === 403) {
+          setPageState("forbidden");
+        } else if (error.httpStatus === 404) {
+          setResults(null);
+          setPageState("empty");
+        } else {
+          setErrorMessage(error.message || "Validation results could not be loaded.");
+          setPageState("error");
+        }
+      }
+    },
+    [allTeams.length, sprintId]
+  );
+
+  const loadPage = useCallback(async () => {
+    setPageState("loading");
+    setErrorMessage(null);
+
     try {
       const active = await getActiveJobForSprint(sprintId);
       if (active) {
         setJobId(active.data.jobId);
         syncJobIdToUrl(active.data.jobId);
-        setPageState('progress');
-      } else {
-        syncJobIdToUrl(null);
-        setJobId(null);
-        setPageState('trigger');
+        setPageState("progress");
+        return;
       }
+      syncJobIdToUrl(null);
+      setJobId(null);
+      await loadResults(selectedTeamId || undefined);
     } catch (err: unknown) {
       const error = err as Error & { httpStatus?: number };
       if (error.httpStatus === 403) {
-        setPageState('forbidden');
-      } else if (error.httpStatus === 404) {
-        setPageState('not_found');
+        setPageState("forbidden");
       } else {
-        setPageState('trigger');
+        await loadResults(selectedTeamId || undefined);
       }
     }
-  }, [sprintId, syncJobIdToUrl]);
+  }, [loadResults, selectedTeamId, sprintId, syncJobIdToUrl]);
 
   useEffect(() => {
-    const raw = searchParams.get('jobId');
+    const raw = searchParams.get("jobId");
     if (raw) {
       setJobId(Number(raw));
-      setPageState('progress');
+      setPageState("progress");
     } else {
-      loadActiveJob();
+      loadPage();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sprintId]);
@@ -91,7 +134,7 @@ function SprintPageLayout() {
     setShowModal(false);
     setJobId(newJobId);
     syncJobIdToUrl(newJobId);
-    setPageState('progress');
+    setPageState("progress");
   };
 
   const handleJobIdChange = (newJobId: number) => {
@@ -99,105 +142,98 @@ function SprintPageLayout() {
     syncJobIdToUrl(newJobId);
   };
 
+  const handleTeamFilterChange = (value: string) => {
+    setSelectedTeamId(value);
+    loadResults(value || undefined, true);
+  };
+
   return (
     <div className="min-h-screen bg-gray-950 flex">
-      <Sidebar activePage="ai-validation" />
+      <Sidebar activePage="ai-validation-sprints" />
       <main className="flex-1 flex flex-col min-w-0">
-        {/* Top bar */}
-        <div className="border-b border-white/5 px-8 py-4 flex items-center justify-between">
+        <div className="border-b border-white/5 px-4 sm:px-8 py-4 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <h1 className="text-base font-semibold text-white">AI Validation</h1>
+            <h1 className="text-base font-semibold text-white">Sprint Results</h1>
             <p className="text-xs text-gray-500 mt-0.5 font-mono">Sprint {sprintId}</p>
           </div>
-          {pageState === 'progress' && (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            {isCoordinator && allTeams.length > 0 && pageState === "results" && (
+              <label className="flex items-center gap-2 text-xs text-gray-500">
+                Team
+                <select
+                  value={selectedTeamId}
+                  onChange={(event) => handleTeamFilterChange(event.target.value)}
+                  className="min-w-48 px-3 py-2 bg-gray-900 border border-white/10 rounded-lg text-sm text-white focus:outline-none focus:border-blue-500/60"
+                >
+                  <option value="">All teams</option>
+                  {allTeams.map((team) => (
+                    <option key={team.id} value={team.id}>{team.name}</option>
+                  ))}
+                </select>
+              </label>
+            )}
             <button
-              onClick={loadActiveJob}
-              className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-xs text-gray-400 hover:text-white hover:bg-white/10 transition-colors"
+              type="button"
+              onClick={loadPage}
+              className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-xs text-gray-300 hover:text-white hover:bg-white/10 transition-colors"
             >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
-              </svg>
+              <RefreshCw className="w-3.5 h-3.5" />
               Refresh
             </button>
-          )}
-        </div>
-
-        <div className="flex-1 p-8">
-          <div className="max-w-2xl mx-auto space-y-5">
-            {pageState === 'loading' && (
-              <div className="bg-gray-900 border border-white/8 rounded-2xl p-12 flex items-center justify-center">
-                <svg className="w-5 h-5 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
-                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-                </svg>
-              </div>
-            )}
-
-            {pageState === 'not_found' && (
-              <div className="bg-gray-900 border border-white/8 rounded-2xl p-10 text-center space-y-3">
-                <div className="w-12 h-12 rounded-2xl bg-gray-800 flex items-center justify-center mx-auto">
-                  <svg className="w-6 h-6 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
-                  </svg>
-                </div>
-                <p className="text-sm font-semibold text-white">Sprint not found</p>
-                <p className="text-xs text-gray-500">The sprint with ID <span className="font-mono text-gray-400">{sprintId}</span> does not exist.</p>
-              </div>
-            )}
-
-            {pageState === 'forbidden' && (
-              <div className="bg-gray-900 border border-white/8 rounded-2xl p-10 text-center space-y-3">
-                <div className="w-12 h-12 rounded-2xl bg-red-500/10 border border-red-500/20 flex items-center justify-center mx-auto">
-                  <svg className="w-6 h-6 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-                  </svg>
-                </div>
-                <p className="text-sm font-semibold text-white">Access Denied</p>
-                <p className="text-xs text-gray-500">You do not have permission to view this sprint&apos;s validation data.</p>
-              </div>
-            )}
-
-            {pageState === 'trigger' && (
-              <div className="bg-gray-900 border border-white/8 rounded-2xl overflow-hidden">
-                <div className="px-6 py-4 border-b border-white/5 flex items-center gap-3">
-                  <div className="w-8 h-8 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-center">
-                    <svg className="w-4 h-4 text-blue-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
-                    </svg>
-                  </div>
-                  <div>
-                    <p className="text-sm font-semibold text-white">No Active Validation</p>
-                    <p className="text-xs text-gray-500">No validation job is running for this sprint</p>
-                  </div>
-                </div>
-                <div className="p-6 space-y-4">
-                  <p className="text-sm text-gray-400">
-                    Run AI validation to verify code review quality and implementation correctness for all issues in this sprint.
-                  </p>
-                  <button
-                    onClick={() => setShowModal(true)}
-                    className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-all shadow-lg shadow-blue-600/20"
-                  >
-                    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 010 1.972l-11.54 6.347a1.125 1.125 0 01-1.667-.986V5.653z" />
-                    </svg>
-                    Run AI Validation
-                  </button>
-                </div>
-              </div>
-            )}
-
-            {pageState === 'progress' && jobId !== null && (
-              <JobProgress jobId={jobId} onJobIdChange={handleJobIdChange} />
+            {isCoordinator && (
+              <button
+                type="button"
+                onClick={() => setShowModal(true)}
+                className="inline-flex items-center justify-center gap-2 px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors"
+              >
+                <Play className="w-4 h-4" />
+                Run AI Validation
+              </button>
             )}
           </div>
+        </div>
+
+        <div className="flex-1 p-4 sm:p-8 overflow-y-auto">
+          {pageState === "loading" && <ResultsSkeleton />}
+
+          {pageState === "progress" && jobId !== null && (
+            <div className="max-w-2xl mx-auto">
+              <JobProgress
+                jobId={jobId}
+                onJobIdChange={handleJobIdChange}
+                onTerminal={(status) => {
+                  if (status !== "FAILED") loadResults(selectedTeamId || undefined);
+                }}
+              />
+            </div>
+          )}
+
+          {pageState === "results" && results && (
+            <SprintResultsDashboard results={results} />
+          )}
+
+          {pageState === "empty" && (
+            <EmptyState isCoordinator={isCoordinator} onRun={() => setShowModal(true)} />
+          )}
+
+          {pageState === "forbidden" && <AccessDenied />}
+
+          {pageState === "error" && (
+            <div className="max-w-2xl mx-auto rounded-lg border border-red-500/20 bg-red-500/5 p-6 flex items-start gap-4">
+              <AlertTriangle className="w-5 h-5 text-red-400 mt-0.5 shrink-0" />
+              <div>
+                <p className="text-sm font-semibold text-white">Validation results could not be loaded</p>
+                <p className="text-sm text-gray-400 mt-1">{errorMessage}</p>
+              </div>
+            </div>
+          )}
         </div>
       </main>
 
-      {showModal && (
+      {showModal && isCoordinator && (
         <TriggerModal
           sprintId={sprintId}
-          teams={teams}
+          teams={teamsForTrigger}
           onClose={() => setShowModal(false)}
           onJobStarted={handleJobStarted}
         />
@@ -206,28 +242,79 @@ function SprintPageLayout() {
   );
 }
 
+function ResultsSkeleton() {
+  return (
+    <div className="space-y-6" aria-label="Loading validation results">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {[0, 1, 2].map((item) => (
+          <div key={item} className="h-36 rounded-lg bg-gray-900 border border-white/8 animate-pulse" />
+        ))}
+      </div>
+      <div className="rounded-lg bg-gray-900 border border-white/8 p-6 animate-pulse">
+        <div className="h-4 w-48 bg-gray-800 rounded" />
+        <div className="mt-6 space-y-3">
+          {[0, 1, 2, 3, 4].map((item) => (
+            <div key={item} className="h-12 bg-gray-800/70 rounded" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({
+  isCoordinator,
+  onRun,
+}: {
+  readonly isCoordinator: boolean;
+  readonly onRun: () => void;
+}) {
+  return (
+    <div className="max-w-xl mx-auto rounded-lg border border-white/8 bg-gray-900 p-10 text-center">
+      <div className="w-14 h-14 rounded-lg bg-gray-800 border border-white/5 flex items-center justify-center mx-auto">
+        <Loader2 className="w-6 h-6 text-gray-500" />
+      </div>
+      <h2 className="text-lg font-semibold text-white mt-5">No validation results yet</h2>
+      <p className="text-sm text-gray-500 mt-2">
+        AI validation has not produced dashboard results for this sprint.
+      </p>
+      {isCoordinator && (
+        <button
+          type="button"
+          onClick={onRun}
+          className="mt-6 inline-flex items-center gap-2 px-5 py-2.5 rounded-lg bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium transition-colors"
+        >
+          <Play className="w-4 h-4" />
+          Run AI Validation
+        </button>
+      )}
+    </div>
+  );
+}
+
 function FullSpinner() {
   return (
     <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-      <svg className="w-6 h-6 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
-        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-      </svg>
+      <Loader2 className="w-6 h-6 animate-spin text-blue-500" />
     </div>
   );
 }
 
 function AccessDenied() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-950">
-      <div className="text-center space-y-4">
-        <div className="w-16 h-16 rounded-2xl bg-red-500/10 border border-red-500/20 flex items-center justify-center mx-auto">
-          <svg className="w-7 h-7 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
-          </svg>
+    <div className="min-h-screen flex items-center justify-center bg-gray-950 p-6">
+      <div className="max-w-sm text-center space-y-4">
+        <div className="w-16 h-16 rounded-lg bg-red-500/10 border border-red-500/20 flex items-center justify-center mx-auto">
+          <ShieldAlert className="w-7 h-7 text-red-400" />
         </div>
-        <h1 className="text-lg font-semibold text-white">Access Restricted</h1>
-        <p className="text-sm text-gray-500">Only Coordinators can access this page.</p>
+        <h1 className="text-lg font-semibold text-white">Access Denied</h1>
+        <p className="text-sm text-gray-500">You do not have permission to view this validation dashboard.</p>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-white/5 border border-white/10 text-sm text-gray-300 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          Back to Dashboard
+        </Link>
       </div>
     </div>
   );

--- a/frontend/app/coordinator/ai-validation/sprints/page.tsx
+++ b/frontend/app/coordinator/ai-validation/sprints/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { useAuthGuard } from '@/hooks/useAuthGuard';
 import Sidebar from '@/components/Sidebar';
 import { buildHeaders, API_BASE } from '@/lib/api-utils';
@@ -15,7 +16,7 @@ interface ActiveSprint {
 }
 
 export default function ValidationSprintsPage() {
-  const authStatus = useAuthGuard('coordinator');
+  const authStatus = useAuthGuard(['coordinator', 'professor']);
   if (authStatus === 'loading') return <FullSpinner />;
   if (authStatus === 'denied') return <AccessDenied />;
   return <SprintsLayout />;
@@ -160,7 +161,13 @@ function AccessDenied() {
           </svg>
         </div>
         <h1 className="text-lg font-semibold text-white">Access Restricted</h1>
-        <p className="text-sm text-gray-500">Only Coordinators can access this page.</p>
+        <p className="text-sm text-gray-500">You do not have permission to access this page.</p>
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-white/5 border border-white/10 text-sm text-gray-300 hover:text-white hover:bg-white/10 transition-colors"
+        >
+          Back to Dashboard
+        </Link>
       </div>
     </div>
   );

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -10,7 +10,7 @@ export default function Sidebar({ activePage }: { activePage: string }) {
   const [user, setUser] = useState<ReturnType<typeof getUser>>(null);
 
   useEffect(() => {
-    setUser(getUser());
+    queueMicrotask(() => setUser(getUser()));
   }, []);
 
   const handleLogout = () => {
@@ -217,6 +217,12 @@ export default function Sidebar({ activePage }: { activePage: string }) {
               active={activePage === "my-advisees"}
               href="/professor/my-advisees"
               icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197" /></svg>}
+            />
+            <NavItem
+              label="Validation Results"
+              active={activePage === "ai-validation-sprints"}
+              href="/coordinator/ai-validation/sprints"
+              icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 3v11.25A2.25 2.25 0 006 16.5h12A2.25 2.25 0 0020.25 14.25V3M7.5 20.25h9M12 16.5v3.75M8.25 9.75l2.25 2.25 5.25-5.25" /></svg>}
             />
             <NavItem
               label="Committees"

--- a/frontend/components/ai-validation/JobProgress.tsx
+++ b/frontend/components/ai-validation/JobProgress.tsx
@@ -46,12 +46,14 @@ function stepLabel(job: JobStatusData): string {
 interface Props {
   readonly jobId: number;
   readonly onJobIdChange?: (newJobId: number) => void;
+  readonly onTerminal?: (status: JobStatus) => void;
 }
 
-export default function JobProgress({ jobId, onJobIdChange }: Props) {
+export default function JobProgress({ jobId, onJobIdChange, onTerminal }: Props) {
   const [job, setJob] = useState<JobStatusData | null>(null);
   const [retrying, setRetrying] = useState(false);
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const terminalNotifiedRef = useRef(false);
 
   const fetchStatus = async (id: number) => {
     try {
@@ -59,6 +61,9 @@ export default function JobProgress({ jobId, onJobIdChange }: Props) {
       setJob(res.data);
       if (!TERMINAL_STATES.has(res.data.jobStatus)) {
         pollRef.current = setTimeout(() => fetchStatus(id), POLL_INTERVAL_MS);
+      } else if (!terminalNotifiedRef.current) {
+        terminalNotifiedRef.current = true;
+        onTerminal?.(res.data.jobStatus);
       }
     } catch (err: unknown) {
       const error = err as Error & { httpStatus?: number };
@@ -73,6 +78,7 @@ export default function JobProgress({ jobId, onJobIdChange }: Props) {
   useEffect(() => {
     if (pollRef.current) clearTimeout(pollRef.current);
     setJob(null);
+    terminalNotifiedRef.current = false;
     fetchStatus(jobId);
     return () => { if (pollRef.current) clearTimeout(pollRef.current); };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/components/ai-validation/SprintResultsDashboard.tsx
+++ b/frontend/components/ai-validation/SprintResultsDashboard.tsx
@@ -1,0 +1,585 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  Check,
+  CheckCircle2,
+  CircleAlert,
+  FileSearch,
+  X,
+} from "lucide-react";
+import {
+  fetchIssueValidationDetails,
+  IssueValidationDetailData,
+  IssueValidationSummary,
+  SprintValidationResultsData,
+  TeamValidationResult,
+} from "@/lib/ai-validation-api";
+import { showToast } from "@/components/toast/ToastContext";
+
+interface Props {
+  readonly results: SprintValidationResultsData;
+}
+
+export default function SprintResultsDashboard({ results }: Props) {
+  const [selectedIssue, setSelectedIssue] = useState<IssueValidationSummary | null>(null);
+  const [detail, setDetail] = useState<IssueValidationDetailData | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const openerRef = useRef<HTMLButtonElement | null>(null);
+
+  const teams = useMemo(() => results.teams ?? [], [results.teams]);
+  const totals = useMemo(() => {
+    const issueCount = teams.reduce((sum, team) => sum + team.issueCount, 0);
+    const validatedCount = teams.reduce(
+      (sum, team) => sum + team.issues.filter((issue) => issue.status === "VALIDATED").length,
+      0
+    );
+    return { issueCount, validatedCount };
+  }, [teams]);
+
+  const openIssue = (issue: IssueValidationSummary, opener: HTMLButtonElement) => {
+    openerRef.current = opener;
+    setSelectedIssue(issue);
+    setDetail(null);
+    setDetailError(null);
+    setDetailLoading(true);
+
+    fetchIssueValidationDetails(issue.issueKey)
+      .then((response) => {
+        setDetail(response.data);
+      })
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : "Issue details could not be loaded.";
+        setDetailError(message);
+        showToast(message, "error");
+      })
+      .finally(() => setDetailLoading(false));
+  };
+
+  const closeDrawer = () => {
+    setSelectedIssue(null);
+    setDetail(null);
+    setDetailError(null);
+    window.setTimeout(() => openerRef.current?.focus(), 0);
+  };
+
+  return (
+    <>
+      <div className="space-y-6">
+        <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          {teams.map((team) => (
+            <TeamScoreCard key={team.teamId} team={team} />
+          ))}
+        </section>
+
+        <section className="bg-gray-900 border border-white/8 rounded-lg overflow-hidden">
+          <div className="px-6 py-4 border-b border-white/5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-sm font-semibold text-white">Sprint Validation Results</h2>
+              <p className="text-xs text-gray-500 mt-1">
+                {totals.validatedCount} validated of {totals.issueCount} issues
+                {results.evaluatedAt ? ` - evaluated ${new Date(results.evaluatedAt).toLocaleString()}` : ""}
+              </p>
+            </div>
+            <div className="flex items-center gap-2 text-xs text-gray-500">
+              <StatusBadge status="VALIDATED" />
+              <StatusBadge status="FAILED" />
+              <StatusBadge status="SKIPPED" />
+            </div>
+          </div>
+
+          <div className="divide-y divide-white/5">
+            {teams.map((team) => (
+              <TeamIssueTable
+                key={team.teamId}
+                team={team}
+                onOpenIssue={openIssue}
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+
+      {selectedIssue && (
+        <IssueDetailDrawer
+          issue={selectedIssue}
+          detail={detail}
+          loading={detailLoading}
+          error={detailError}
+          onClose={closeDrawer}
+        />
+      )}
+    </>
+  );
+}
+
+function TeamScoreCard({ team }: { readonly team: TeamValidationResult }) {
+  return (
+    <article className="bg-gray-900 border border-white/8 rounded-lg p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-xs text-gray-500">Team</p>
+          <h3 className="text-base font-semibold text-white truncate mt-1">{team.teamName}</h3>
+          <p className="text-xs text-gray-600 mt-1">Team #{team.teamId}</p>
+        </div>
+        <ScorePill score={team.overallSprintScore} />
+      </div>
+      <div className="mt-5 grid grid-cols-2 gap-3">
+        <Metric label="Overall Score" value={formatScore(team.overallSprintScore)} />
+        <Metric label="Issues" value={String(team.issueCount)} />
+      </div>
+    </article>
+  );
+}
+
+function Metric({ label, value }: { readonly label: string; readonly value: string }) {
+  return (
+    <div className="bg-gray-800/70 border border-white/5 rounded-lg px-3 py-2">
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="text-sm font-semibold text-white mt-1">{value}</p>
+    </div>
+  );
+}
+
+function TeamIssueTable({
+  team,
+  onOpenIssue,
+}: {
+  readonly team: TeamValidationResult;
+  readonly onOpenIssue: (issue: IssueValidationSummary, opener: HTMLButtonElement) => void;
+}) {
+  return (
+    <div>
+      <div className="px-6 py-4 flex items-center justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold text-white">{team.teamName}</h3>
+          <p className="text-xs text-gray-500 mt-1">{team.issueCount} issue{team.issueCount === 1 ? "" : "s"}</p>
+        </div>
+        <ScorePill score={team.overallSprintScore} />
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[1120px]">
+          <thead>
+            <tr className="border-y border-white/5 bg-gray-950/40">
+              <ColumnHeader>Issue</ColumnHeader>
+              <ColumnHeader>Assignee</ColumnHeader>
+              <ColumnHeader>PR</ColumnHeader>
+              <ColumnHeader>Merged</ColumnHeader>
+              <ColumnHeader>Review</ColumnHeader>
+              <ColumnHeader>Implementation</ColumnHeader>
+              <ColumnHeader>Composite</ColumnHeader>
+              <ColumnHeader>Review Quality</ColumnHeader>
+              <ColumnHeader>Status</ColumnHeader>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-white/5">
+            {team.issues.map((issue) => (
+              <tr key={issue.issueKey} className="hover:bg-white/[0.03] transition-colors">
+                <td className="px-6 py-4 align-top">
+                  <button
+                    type="button"
+                    onClick={(event) => onOpenIssue(issue, event.currentTarget)}
+                    className="text-left group"
+                  >
+                    <span className="text-sm font-semibold text-blue-400 group-hover:text-blue-300">
+                      {issue.issueKey}
+                    </span>
+                    {issue.issueTitle && (
+                      <span className="block text-xs text-gray-500 mt-1 max-w-[240px] truncate">
+                        {issue.issueTitle}
+                      </span>
+                    )}
+                  </button>
+                </td>
+                <td className="px-6 py-4 text-sm text-gray-300 align-top">{issue.assignee || "-"}</td>
+                <td className="px-6 py-4 text-sm text-gray-300 align-top">
+                  {issue.prNumber ? <span className="font-mono">#{issue.prNumber}</span> : "-"}
+                </td>
+                <td className="px-6 py-4 align-top">
+                  <BooleanMark value={issue.prMerged} />
+                </td>
+                <td className="px-6 py-4 align-top">
+                  <ScoreText score={issue.reviewVerificationScore} />
+                </td>
+                <td className="px-6 py-4 align-top">
+                  <ScoreText score={issue.implementationMatchScore} />
+                </td>
+                <td className="px-6 py-4 align-top">
+                  <ScoreText score={issue.compositeScore} strong />
+                </td>
+                <td className="px-6 py-4 align-top">
+                  {issue.reviewQuality ? <ReviewQualityChip quality={issue.reviewQuality} /> : <span className="text-xs text-gray-600">-</span>}
+                </td>
+                <td className="px-6 py-4 align-top">
+                  <StatusBadge status={issue.status} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ColumnHeader({ children }: { readonly children: React.ReactNode }) {
+  return (
+    <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+      {children}
+    </th>
+  );
+}
+
+function IssueDetailDrawer({
+  issue,
+  detail,
+  loading,
+  error,
+  onClose,
+}: {
+  readonly issue: IssueValidationSummary;
+  readonly detail: IssueValidationDetailData | null;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly onClose: () => void;
+}) {
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    drawerRef.current?.focus();
+  }, []);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+
+    if (event.key !== "Tab" || !drawerRef.current) return;
+
+    const focusable = getFocusableElements(drawerRef.current);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const review = detail?.reviewVerification;
+  const implementation = detail?.implementationValidation;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/60 cursor-default"
+        aria-label="Close issue details"
+        onClick={onClose}
+      />
+      <aside
+        ref={drawerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="issue-detail-title"
+        tabIndex={-1}
+        onKeyDown={handleKeyDown}
+        className="relative h-full w-full max-w-2xl bg-gray-950 border-l border-white/10 shadow-2xl overflow-y-auto focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70"
+      >
+        <div className="sticky top-0 z-10 bg-gray-950/95 backdrop-blur border-b border-white/8 px-6 py-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 id="issue-detail-title" className="text-base font-semibold text-white">
+              {issue.issueKey}
+            </h2>
+            <p className="text-xs text-gray-500 mt-1">{issue.issueTitle || detail?.issueDescription || "Issue validation detail"}</p>
+          </div>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            className="w-9 h-9 rounded-lg flex items-center justify-center text-gray-500 hover:text-white hover:bg-white/5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70"
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="p-6 space-y-5">
+          {loading && <DrawerSkeleton />}
+
+          {error && (
+            <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4 flex items-start gap-3">
+              <CircleAlert className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
+              <p className="text-sm text-red-200">{error}</p>
+            </div>
+          )}
+
+          {detail && (
+            <>
+              <section className="rounded-lg border border-white/8 bg-gray-900 p-5">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <h3 className="text-sm font-semibold text-white">Issue Context</h3>
+                    <p className="text-sm text-gray-400 mt-2">{detail.issueDescription || "No issue description provided."}</p>
+                  </div>
+                  <StatusBadge status={issue.status} />
+                </div>
+                <div className="mt-4 grid grid-cols-2 sm:grid-cols-4 gap-3">
+                  <Metric label="PR" value={detail.prNumber ? `#${detail.prNumber}` : "-"} />
+                  <Metric label="Merged" value={formatBool(issue.prMerged)} />
+                  <Metric label="Composite" value={formatScore(issue.compositeScore)} />
+                  <Metric label="Evaluated" value={detail.evaluatedAt ? new Date(detail.evaluatedAt).toLocaleDateString() : "-"} />
+                </div>
+                {detail.prUrl && (
+                  <a
+                    href={detail.prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex mt-4 text-xs font-medium text-blue-400 hover:text-blue-300"
+                  >
+                    Open pull request
+                  </a>
+                )}
+              </section>
+
+              <section className="rounded-lg border border-white/8 bg-gray-900 p-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-sm font-semibold text-white">Review Verification</h3>
+                    <p className="text-xs text-gray-500 mt-1">Reviewer activity, review substance, and AI feedback</p>
+                  </div>
+                  <ScorePill score={review?.score} />
+                </div>
+                <div className="mt-4 grid grid-cols-2 gap-3">
+                  <BooleanCard label="Has review" value={review?.hasReview} />
+                  <BooleanCard label="PR merged" value={issue.prMerged} />
+                  <BooleanCard label="Change requests" value={review?.hasChangeRequests} />
+                  <BooleanCard label="Substantive comments" value={review?.hasSubstantiveComments} />
+                </div>
+                <div className="mt-4 flex flex-wrap items-center gap-3">
+                  <Metric label="Reviewer Count" value={String(review?.reviewerCount ?? 0)} />
+                  {review?.reviewQuality && <ReviewQualityChip quality={review.reviewQuality} />}
+                </div>
+                <Feedback text={review?.aiFeedback} />
+              </section>
+
+              <section className="rounded-lg border border-white/8 bg-gray-900 p-5">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-sm font-semibold text-white">Implementation Validation</h3>
+                    <p className="text-xs text-gray-500 mt-1">Requirement coverage, missing work, and analyzed diff scope</p>
+                  </div>
+                  <ScorePill score={implementation?.score} />
+                </div>
+
+                {implementation?.diffTruncated && (
+                  <div className="mt-4 rounded-lg border border-amber-500/25 bg-amber-500/10 p-4 flex items-start gap-3">
+                    <AlertTriangle className="w-4 h-4 text-amber-300 mt-0.5 shrink-0" />
+                    <p className="text-sm text-amber-100">
+                      Diff was truncated before AI analysis. Some changed lines may not be represented in this feedback.
+                    </p>
+                  </div>
+                )}
+
+                <div className="mt-4 grid grid-cols-2 gap-3">
+                  <BooleanCard label="Implementation valid" value={implementation?.isValid} />
+                  <Metric label="Files Analyzed" value={String(implementation?.filesAnalyzed ?? 0)} />
+                </div>
+
+                <div className="mt-5">
+                  <h4 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Coverage Areas</h4>
+                  <div className="mt-3 space-y-2">
+                    {(implementation?.coverageAreas ?? []).length > 0 ? (
+                      implementation?.coverageAreas?.map((area, index) => (
+                        <div key={`${area.requirement}-${index}`} className="flex items-start gap-3 rounded-lg bg-gray-800/70 border border-white/5 px-3 py-2">
+                          {area.covered ? (
+                            <CheckCircle2 className="w-4 h-4 text-green-400 mt-0.5 shrink-0" />
+                          ) : (
+                            <CircleAlert className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
+                          )}
+                          <span className="text-sm text-gray-300">{area.requirement}</span>
+                        </div>
+                      ))
+                    ) : (
+                      <p className="text-sm text-gray-500">No coverage areas reported.</p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="mt-5">
+                  <h4 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Missing Requirements</h4>
+                  <div className="mt-3 space-y-2">
+                    {(implementation?.missingRequirements ?? []).length > 0 ? (
+                      implementation?.missingRequirements?.map((requirement, index) => (
+                        <div key={`${requirement}-${index}`} className="rounded-lg bg-red-500/5 border border-red-500/20 px-3 py-2 text-sm text-red-100">
+                          {requirement}
+                        </div>
+                      ))
+                    ) : (
+                      <p className="text-sm text-gray-500">No missing requirements reported.</p>
+                    )}
+                  </div>
+                </div>
+
+                <Feedback text={implementation?.aiFeedback} />
+              </section>
+
+              <div className="flex justify-end pb-4">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="px-4 py-2 rounded-lg border border-white/10 bg-white/5 text-sm font-medium text-gray-300 hover:text-white hover:bg-white/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70"
+                >
+                  Close
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+function DrawerSkeleton() {
+  return (
+    <div className="space-y-4" aria-label="Loading issue details">
+      {[0, 1, 2].map((item) => (
+        <div key={item} className="rounded-lg border border-white/8 bg-gray-900 p-5 animate-pulse">
+          <div className="h-4 w-40 bg-gray-800 rounded" />
+          <div className="mt-4 h-3 w-full bg-gray-800 rounded" />
+          <div className="mt-2 h-3 w-2/3 bg-gray-800 rounded" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Feedback({ text }: { readonly text?: string | null }) {
+  return (
+    <div className="mt-5 rounded-lg bg-gray-800/70 border border-white/5 p-4">
+      <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">AI Feedback</p>
+      <p className="text-sm text-gray-300 mt-2 whitespace-pre-wrap">{text || "No AI feedback provided."}</p>
+    </div>
+  );
+}
+
+function BooleanCard({ label, value }: { readonly label: string; readonly value?: boolean | null }) {
+  const known = typeof value === "boolean";
+  return (
+    <div className="rounded-lg bg-gray-800/70 border border-white/5 px-3 py-3">
+      <p className="text-xs text-gray-500">{label}</p>
+      <div className="mt-2 flex items-center gap-2">
+        {known && value ? (
+          <Check className="w-4 h-4 text-green-400" />
+        ) : known ? (
+          <X className="w-4 h-4 text-red-400" />
+        ) : (
+          <FileSearch className="w-4 h-4 text-gray-500" />
+        )}
+        <span className={`text-sm font-medium ${known ? (value ? "text-green-300" : "text-red-300") : "text-gray-500"}`}>
+          {formatBool(value)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function BooleanMark({ value }: { readonly value?: boolean | null }) {
+  if (typeof value !== "boolean") return <span className="text-xs text-gray-600">-</span>;
+  return (
+    <span className={value ? "text-green-400" : "text-red-400"}>
+      {value ? "Yes" : "No"}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { readonly status: IssueValidationSummary["status"] }) {
+  const styles = {
+    VALIDATED: "bg-green-500/10 text-green-300 border-green-500/25",
+    FAILED: "bg-red-500/10 text-red-300 border-red-500/25",
+    SKIPPED: "bg-gray-500/10 text-gray-300 border-gray-500/25",
+  };
+
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${styles[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+function ReviewQualityChip({ quality }: { readonly quality: NonNullable<IssueValidationSummary["reviewQuality"]> }) {
+  const styles = {
+    THOROUGH: "bg-green-500/10 text-green-300 border-green-500/25",
+    SUFFICIENT: "bg-blue-500/10 text-blue-300 border-blue-500/25",
+    MINIMAL: "bg-amber-500/10 text-amber-300 border-amber-500/25",
+    INSUFFICIENT: "bg-red-500/10 text-red-300 border-red-500/25",
+  };
+
+  return (
+    <span className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${styles[quality]}`}>
+      {quality}
+    </span>
+  );
+}
+
+function ScorePill({ score }: { readonly score?: number | null }) {
+  return (
+    <span className={`inline-flex items-center justify-center min-w-16 rounded-lg px-3 py-2 text-sm font-bold ${scoreBgClass(score)}`}>
+      {formatScore(score)}
+    </span>
+  );
+}
+
+function ScoreText({ score, strong = false }: { readonly score?: number | null; readonly strong?: boolean }) {
+  return (
+    <span className={`${strong ? "font-semibold" : "font-medium"} ${scoreTextClass(score)}`}>
+      {formatScore(score)}
+    </span>
+  );
+}
+
+function scoreTextClass(score?: number | null): string {
+  if (typeof score !== "number") return "text-gray-600";
+  if (score >= 80) return "text-green-400";
+  if (score >= 60) return "text-amber-400";
+  return "text-red-400";
+}
+
+function scoreBgClass(score?: number | null): string {
+  if (typeof score !== "number") return "bg-gray-800 text-gray-500 border border-white/5";
+  if (score >= 80) return "bg-green-500/10 text-green-300 border border-green-500/25";
+  if (score >= 60) return "bg-amber-500/10 text-amber-300 border border-amber-500/25";
+  return "bg-red-500/10 text-red-300 border border-red-500/25";
+}
+
+function formatScore(score?: number | null): string {
+  return typeof score === "number" ? score.toFixed(1) : "-";
+}
+
+function formatBool(value?: boolean | null): string {
+  if (typeof value !== "boolean") return "Unknown";
+  return value ? "Yes" : "No";
+}
+
+function getFocusableElements(root: HTMLElement): HTMLElement[] {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter((element) => !element.hasAttribute("disabled") && element.tabIndex !== -1);
+}

--- a/frontend/hooks/useAuthGuard.ts
+++ b/frontend/hooks/useAuthGuard.ts
@@ -5,9 +5,10 @@ import { getToken, getUser } from "@/lib/auth";
 
 export type AuthGuardStatus = "loading" | "authorized" | "denied";
 
-export function useAuthGuard(requiredRole: string): AuthGuardStatus {
+export function useAuthGuard(requiredRole: string | string[]): AuthGuardStatus {
     const router = useRouter();
     const [status, setStatus] = useState<AuthGuardStatus>("loading");
+    const requiredRoleKey = Array.isArray(requiredRole) ? requiredRole.join("|") : requiredRole;
 
     useEffect(() => {
         const token = getToken();
@@ -20,8 +21,11 @@ export function useAuthGuard(requiredRole: string): AuthGuardStatus {
             router.replace("/auth/change-password");
             return;
         }
-        setStatus(user.role === requiredRole ? "authorized" : "denied");
-    }, [router, requiredRole]);
+        const allowedRoles = requiredRoleKey.split("|");
+        queueMicrotask(() => {
+            setStatus(allowedRoles.includes(user.role) ? "authorized" : "denied");
+        });
+    }, [router, requiredRoleKey]);
 
     return status;
 }

--- a/frontend/lib/ai-validation-api.ts
+++ b/frontend/lib/ai-validation-api.ts
@@ -81,6 +81,91 @@ export interface JobStatusResponse {
   data: JobStatusData;
 }
 
+export type ValidationIssueStatus = "VALIDATED" | "FAILED" | "SKIPPED";
+export type ReviewQuality = "THOROUGH" | "SUFFICIENT" | "MINIMAL" | "INSUFFICIENT";
+
+export interface IssueValidationSummary {
+  issueKey: string;
+  issueTitle?: string | null;
+  assignee?: string | null;
+  prNumber?: number | null;
+  prMerged?: boolean | null;
+  reviewVerificationScore?: number | null;
+  reviewQuality?: ReviewQuality | null;
+  implementationMatchScore?: number | null;
+  compositeScore?: number | null;
+  status: ValidationIssueStatus;
+}
+
+export interface TeamValidationResult {
+  teamId: number | string;
+  teamName: string;
+  overallSprintScore: number;
+  issueCount: number;
+  issues: IssueValidationSummary[];
+}
+
+export interface SprintValidationResultsData {
+  sprintId: number | string;
+  evaluatedAt?: string | null;
+  teams: TeamValidationResult[];
+}
+
+export interface SprintValidationResultsResponse {
+  status: string;
+  data: SprintValidationResultsData;
+}
+
+export interface CoverageArea {
+  requirement: string;
+  covered: boolean | null;
+}
+
+export interface IssueValidationDetailData {
+  issueKey: string;
+  issueDescription?: string | null;
+  prNumber?: number | null;
+  prUrl?: string | null;
+  evaluatedAt?: string | null;
+  reviewVerification: {
+    score?: number | null;
+    hasReview?: boolean | null;
+    reviewQuality?: ReviewQuality | null;
+    reviewerCount?: number | null;
+    hasChangeRequests?: boolean | null;
+    hasSubstantiveComments?: boolean | null;
+    aiFeedback?: string | null;
+  };
+  implementationValidation: {
+    score?: number | null;
+    isValid?: boolean | null;
+    coverageAreas?: CoverageArea[];
+    missingRequirements?: string[];
+    aiFeedback?: string | null;
+    filesAnalyzed?: number | null;
+    diffTruncated?: boolean | null;
+  };
+}
+
+export interface IssueValidationDetailResponse {
+  status: string;
+  data: IssueValidationDetailData;
+}
+
+interface ApiErrorBody {
+  message?: string;
+  error?: string;
+  errorCode?: string;
+}
+
+async function throwApiError(res: Response, fallback: string): Promise<never> {
+  const data = await res.json().catch(() => ({})) as ApiErrorBody;
+  throw Object.assign(new Error(data.message || data.error || fallback), {
+    errorCode: data.errorCode || data.error,
+    httpStatus: res.status,
+  });
+}
+
 // ── API — Config ───────────────────────────────────────────────────────────
 
 export async function fetchValidationConfig(): Promise<ValidationConfigResponse> {
@@ -174,6 +259,45 @@ export async function getActiveJobForSprint(
       errorCode: data.error,
       httpStatus: res.status,
     });
+  }
+  return res.json();
+}
+
+/** GET /ai-validation/sprints/{sprintId}/results */
+export async function fetchSprintValidationResults(
+  sprintId: string,
+  teamId?: string
+): Promise<SprintValidationResultsResponse> {
+  const params = new URLSearchParams();
+  if (teamId) params.set("teamId", teamId);
+  const query = params.toString();
+
+  const res = await fetch(
+    `${API_BASE}/ai-validation/sprints/${sprintId}/results${query ? `?${query}` : ""}`,
+    {
+      headers: buildHeaders(),
+      cache: "no-store",
+    }
+  );
+  if (!res.ok) {
+    await throwApiError(res, "Failed to fetch validation results.");
+  }
+  return res.json();
+}
+
+/** GET /ai-validation/issues/{issueKey}/details */
+export async function fetchIssueValidationDetails(
+  issueKey: string
+): Promise<IssueValidationDetailResponse> {
+  const res = await fetch(
+    `${API_BASE}/ai-validation/issues/${encodeURIComponent(issueKey)}/details`,
+    {
+      headers: buildHeaders(),
+      cache: "no-store",
+    }
+  );
+  if (!res.ok) {
+    await throwApiError(res, "Failed to fetch issue details.");
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary

Implements the Process 7 Advisor/Coordinator validation results UI for sprint-level AI validation outputs.

This PR ships the Sprint Results dashboard, per-team issue tables, issue drill-down drawer, and Coordinator-only configuration/admin UI integration for the FS-02 / Process 7 API surface.

Resolves #300  
Related: #296, #298

## Changes

- Added Sprint Results dashboard for `GET /ai-validation/sprints/{sprintId}/results`
  - Renders one card per team with `teamName`, `overallSprintScore`, and `issueCount`
  - Renders per-team issue tables with issue key, assignee, PR metadata, review score, implementation score, composite score, review quality, and status
  - Supports Coordinator `teamId` filtering
  - Shows loading skeletons while results are loading
  - Shows empty state with `No validation results yet`
  - Shows `Run AI Validation` CTA only for Coordinators

- Added issue detail drill-down drawer for `GET /ai-validation/issues/{issueKey}/details`
  - Displays review verification details
  - Displays implementation validation details
  - Shows coverage areas checklist
  - Shows missing requirements
  - Shows AI feedback blocks
  - Shows `diffTruncated` warning banner when applicable

- Added drawer accessibility behavior
  - Focus moves into the drawer on open
  - Focus is trapped inside the drawer while open
  - `Escape` closes the drawer
  - Focus returns to the issue row/button that opened the drawer

- Updated AI validation API client types and fetch helpers
  - Added typed Sprint Results response models
  - Added typed Issue Detail response models
  - Preserves HTTP status and API error codes for UI branching

- Updated role handling for Process 7 read access
  - Treats local `professor` role as the advisor-facing role for validation result reads
  - Keeps Coordinator-only config and trigger controls restricted to Coordinators

- Improved Coordinator config UI behavior
  - Added loading skeletons
  - Added access denied link back to dashboard

## Acceptance Criteria Coverage

- [x] Advisor sees only their advisee teams' cards
- [x] Coordinator sees all teams
- [x] Coordinator `teamId` filter narrows results
- [x] Composite score color rules implemented:
  - `>= 80` green
  - `60-79` amber
  - `< 60` red
- [x] Status badges implemented:
  - `VALIDATED` green
  - `FAILED` red
  - `SKIPPED` grey
- [x] `reviewQuality` chip implemented:
  - `THOROUGH`
  - `SUFFICIENT`
  - `MINIMAL`
  - `INSUFFICIENT`
- [x] Issue detail drawer shows review verification fields
- [x] Issue detail drawer shows implementation validation fields
- [x] `diffTruncated: true` renders warning banner
- [x] `404` results state renders empty state
- [x] `Run AI Validation` CTA is Coordinator-only
- [x] `403` renders access denied view with dashboard link
- [x] Config admin page is Coordinator-only in navigation
- [x] Cards stack to one column under `768px`
- [x] Loading skeletons render while fetches are in flight
- [x] Drawer focus management, focus trap, ESC close, and focus return implemented

## Manual Validation

Validated locally with:

- Coordinator account
- Professor account
- Sprint ID `122`

Confirmed:

- Coordinator login succeeds
- Professor login succeeds
- Coordinator can access validation config
- Professor receives `403` for validation config
- Coordinator results dashboard renders for Sprint `122`
- Team card renders for validated team data
- Issue table renders skipped issues
- Issue detail drawer opens from issue rows
- Drawer displays review and implementation sections
- Drawer keyboard behavior works:
  - focus enters drawer
  - Tab stays within drawer controls
  - ESC closes drawer
  - focus returns to the opener

## Testing

Targeted ESLint passed for the changed frontend files:

```bash
eslint lib/ai-validation-api.ts \
  hooks/useAuthGuard.ts \
  components/ai-validation/SprintResultsDashboard.tsx \
  components/ai-validation/JobProgress.tsx \
  app/coordinator/ai-validation/config/page.tsx \
  app/coordinator/ai-validation/sprints/page.tsx \
  app/coordinator/ai-validation/sprints/[sprintId]/page.tsx \
  components/Sidebar.tsx
