### PR TITLE
fix: Notification page loading state and deletion persistence

### DIFF
--- a/backend/src/main/java/com/spms/backend/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/NotificationRepository.java
@@ -14,7 +14,12 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     Page<Notification> findByToUser_UserId(Long toUserId, Pageable pageable);
 
+    Page<Notification> findByToUser_UserIdAndStatusNot(Long toUserId, NotificationStatus status, Pageable pageable);
+
     Page<Notification> findByToUser_UserIdAndReadStatus(Long toUserId, boolean readStatus, Pageable pageable);
+
+    Page<Notification> findByToUser_UserIdAndReadStatusAndStatusNot(
+            Long toUserId, boolean readStatus, NotificationStatus status, Pageable pageable);
 
     Optional<Notification> findByGroupIdAndTypeAndStatus(Long groupId, NotificationType type, NotificationStatus status);
 

--- a/backend/src/main/java/com/spms/backend/service/impl/NotificationServiceImpl.java
+++ b/backend/src/main/java/com/spms/backend/service/impl/NotificationServiceImpl.java
@@ -184,15 +184,18 @@ public class NotificationServiceImpl implements NotificationService {
     @Transactional(readOnly = true)
     public Page<NotificationDto> getNotifications(Long userId, String readStatus, Pageable pageable) {
         if ("UNREAD".equalsIgnoreCase(readStatus)) {
-            return notificationRepository.findByToUser_UserIdAndReadStatus(userId, false, pageable)
+            return notificationRepository.findByToUser_UserIdAndReadStatusAndStatusNot(
+                            userId, false, NotificationStatus.CLEARED, pageable)
                     .map(this::mapToDto);
         }
         if ("READ".equalsIgnoreCase(readStatus)) {
-            return notificationRepository.findByToUser_UserIdAndReadStatus(userId, true, pageable)
+            return notificationRepository.findByToUser_UserIdAndReadStatusAndStatusNot(
+                            userId, true, NotificationStatus.CLEARED, pageable)
                     .map(this::mapToDto);
         }
         if ("ALL".equalsIgnoreCase(readStatus)) {
-            return notificationRepository.findByToUser_UserId(userId, pageable)
+            return notificationRepository.findByToUser_UserIdAndStatusNot(
+                            userId, NotificationStatus.CLEARED, pageable)
                     .map(this::mapToDto);
         }
         throw new BadRequestException("Invalid readStatus. Supported values: UNREAD, READ, or ALL.");

--- a/backend/src/test/java/com/spms/backend/service/AdvisorRequestDetailServiceTest.java
+++ b/backend/src/test/java/com/spms/backend/service/AdvisorRequestDetailServiceTest.java
@@ -217,7 +217,9 @@ class AdvisorRequestDetailServiceTest {
         @Override public void deleteAll() { store.clear(); }
 
         @Override public Page<Notification> findByToUser_UserId(Long toUserId, Pageable pageable) { return Page.empty(); }
+        @Override public Page<Notification> findByToUser_UserIdAndStatusNot(Long toUserId, NotificationStatus status, Pageable pageable) { return Page.empty(); }
         @Override public Page<Notification> findByToUser_UserIdAndReadStatus(Long toUserId, boolean readStatus, Pageable pageable) { return Page.empty(); }
+        @Override public Page<Notification> findByToUser_UserIdAndReadStatusAndStatusNot(Long toUserId, boolean readStatus, NotificationStatus status, Pageable pageable) { return Page.empty(); }
         @Override public Optional<Notification> findByGroupIdAndTypeAndStatus(Long groupId, NotificationType type, com.spms.backend.model.notification.NotificationStatus status) { return Optional.empty(); }
         @Override public Optional<Notification> findByGroupIdAndToUser_UserIdAndTypeAndStatus(Long groupId, Long toUserId, NotificationType type, com.spms.backend.model.notification.NotificationStatus status) { return Optional.empty(); }
         @Override public void deleteByToUser_UserId(Long userId) {}

--- a/frontend/app/notifications/page.tsx
+++ b/frontend/app/notifications/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Sidebar from "@/components/Sidebar";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import NotificationList from "@/components/NotificationList";
 import { useNotifications } from "@/components/NotificationProvider";
@@ -9,9 +9,28 @@ export default function NotificationsPage() {
     const router = useRouter();
     const {
         notifications,
+        loading,
         respondToNotification,
         clearNotification,
+        refresh,
     } = useNotifications();
+
+    // Always trigger a fresh fetch when this page mounts so we never show
+    // stale empty state from a previously failed/incomplete provider load.
+    const [isPageLoading, setIsPageLoading] = useState(true);
+
+    useEffect(() => {
+        setIsPageLoading(true);
+        refresh();
+    }, [refresh]);
+
+    // Once the provider's loading flag drops to false (fetch settled),
+    // mark our local page-loading as done too.
+    useEffect(() => {
+        if (!loading) {
+            setIsPageLoading(false);
+        }
+    }, [loading]);
 
     const [page, setPage] = useState(0);
     const pageSize = 4;
@@ -63,6 +82,7 @@ export default function NotificationsPage() {
 
                     <NotificationList
                         notifications={paginatedNotifications}
+                        loading={isPageLoading || loading}
                         page={page}
                         totalPages={totalPages}
                         onRespond={respondToNotification}

--- a/frontend/components/NotificationList.tsx
+++ b/frontend/components/NotificationList.tsx
@@ -8,6 +8,7 @@ import {
 
 type Props = {
     notifications: Notification[];
+    loading?: boolean;
     page: number;
     totalPages: number;
     onRespond: (id: number, decision: NotificationDecision) => Promise<void>;
@@ -16,8 +17,24 @@ type Props = {
     onNextPage: () => void;
 };
 
+function SkeletonCard() {
+    return (
+        <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-5 shadow-lg shadow-black/20 backdrop-blur animate-pulse">
+            <div className="flex items-start gap-4">
+                <div className="h-10 w-10 rounded-full bg-white/10 flex-shrink-0" />
+                <div className="flex-1 space-y-3">
+                    <div className="h-4 w-3/4 rounded-lg bg-white/10" />
+                    <div className="h-3 w-1/2 rounded-lg bg-white/5" />
+                    <div className="h-3 w-1/4 rounded-lg bg-white/5" />
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export default function NotificationList({
     notifications,
+    loading = false,
     page,
     totalPages,
     onRespond,
@@ -25,6 +42,16 @@ export default function NotificationList({
     onPrevPage,
     onNextPage,
 }: Props) {
+    if (loading) {
+        return (
+            <div className="space-y-4">
+                {[...Array(3)].map((_, i) => (
+                    <SkeletonCard key={i} />
+                ))}
+            </div>
+        );
+    }
+
     if (notifications.length === 0) {
         return (
             <div className="rounded-2xl border border-white/10 bg-gray-900/70 p-8 text-center shadow-lg shadow-black/20 backdrop-blur">


### PR DESCRIPTION
## Summary

This PR fixes two separate bugs in the notifications feature:

### Fix 1: Loading skeleton instead of empty state

**Problem:** When navigating to the notifications page, "No notifications" was briefly shown before data loaded (~20 seconds via polling). This was misleading to users.

**Changes:**
- `NotificationList.tsx` — Added a `loading` prop. When `true`, renders 3 animated skeleton cards (pulse animation) instead of the empty state.
- `notifications/page.tsx` — Reads the `loading` flag from `useNotifications()` context and passes it to `NotificationList`. Also triggers a `refresh()` on page mount with a local `isPageLoading` guard to ensure the skeleton always shows on first visit, even if the provider had already completed a previous (failed) load.

### Fix 2: Deleted notifications reappearing after page refresh

**Problem:** Clearing a notification only soft-deleted it (status → `CLEARED`) but the `getNotifications` query returned all statuses, so cleared notifications came back on refresh.

**Changes:**
- `NotificationRepository.java` — Added two new query methods that exclude `CLEARED` status:
  - `findByToUser_UserIdAndStatusNot(...)`
  - `findByToUser_UserIdAndReadStatusAndStatusNot(...)`
- `NotificationServiceImpl.java` — Updated `getNotifications()` to use the new queries for all three filter modes (ALL, UNREAD, READ).
- `AdvisorRequestDetailServiceTest.java` — Added missing stub overrides for the two new repository methods to fix test compilation error.


## Testing

- Verified skeleton cards appear on first login navigation to `/notifications`
- Verified "No notifications" no longer flashes before data loads
- Verified deleted notifications do not reappear after page refresh
- Backend compiles and all tests pass
