### PR TITLE
feat: add admin password reset via email

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,6 +28,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>

--- a/backend/src/main/java/com/spms/backend/controller/AdminController.java
+++ b/backend/src/main/java/com/spms/backend/controller/AdminController.java
@@ -5,7 +5,7 @@ import com.spms.backend.dto.response.ResetLinkResponse;
 import com.spms.backend.exception.BadRequestException;
 import com.spms.backend.model.User;
 import com.spms.backend.repository.UserRepository;
-import com.spms.backend.service.PasswordHashingService;
+import com.spms.backend.service.EmailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,18 +34,18 @@ import com.spms.backend.repository.AuditLogRepository;
 public class AdminController {
 
     private final UserRepository userRepository;
-    private final PasswordHashingService passwordHashingService;
+    private final EmailService emailService;
     private final AuditLogRepository auditLogRepository;
 
     public AdminController(UserRepository userRepository,
-                           PasswordHashingService passwordHashingService,
+                           EmailService emailService,
                            AuditLogRepository auditLogRepository) {
         this.userRepository = userRepository;
-        this.passwordHashingService = passwordHashingService;
+        this.emailService = emailService;
         this.auditLogRepository = auditLogRepository;
     }
 
-    @Operation(summary = "Generate one-time password reset link for a professor")
+    @Operation(summary = "Generate one-time password reset link and send via email")
     @PostMapping("/generate-reset-link")
     public ResponseEntity<ResetLinkResponse> generateResetLink(
             @Valid @RequestBody ResetLinkRequest request
@@ -54,20 +54,18 @@ public class AdminController {
                 .orElseThrow(() -> new BadRequestException(
                         "Professor not found for the given email."));
 
-        // Tek kullanımlık token üret
         String resetToken = UUID.randomUUID().toString();
 
-        // Geçici şifre olarak token'ı hash'le ve kullanıcıyı güncelle
-        user.setPasswordHash(passwordHashingService.hashPassword(resetToken));
+        user.setPasswordResetToken(resetToken);
         user.setRequiresPasswordChange(true);
         userRepository.save(user);
 
-        String resetUrl = "http://localhost:3000/auth/change-password?token=" + resetToken;
+        emailService.sendPasswordResetEmail(user.getEmail(), user.getFullName(), resetToken);
 
         return ResponseEntity.ok(new ResetLinkResponse(
-                "Password reset link generated successfully.",
+                "Password reset email sent successfully.",
                 resetToken,
-                resetUrl
+                null
         ));
     }
     @Operation(summary = "Get global audit logs")

--- a/backend/src/main/java/com/spms/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/spms/backend/controller/AuthController.java
@@ -133,14 +133,11 @@ public class AuthController {
             throw new BadRequestException("newPassword is required.");
         }
 
-        User user = userRepository.findAll().stream()
-                .filter(u -> u.isRequiresPasswordChange()
-                        && u.getPasswordHash() != null
-                        && passwordHashingService.matchesPassword(token, u.getPasswordHash()))
-                .findFirst()
+        User user = userRepository.findByPasswordResetToken(token)
                 .orElseThrow(() -> new UnauthorizedException("Invalid or expired reset token."));
 
         user.setPasswordHash(passwordHashingService.hashPassword(newPassword));
+        user.setPasswordResetToken(null);
         user.setRequiresPasswordChange(false);
         userRepository.save(user);
 

--- a/backend/src/main/java/com/spms/backend/exception/EmailException.java
+++ b/backend/src/main/java/com/spms/backend/exception/EmailException.java
@@ -1,0 +1,7 @@
+package com.spms.backend.exception;
+
+public class EmailException extends RuntimeException {
+    public EmailException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/com/spms/backend/model/User.java
+++ b/backend/src/main/java/com/spms/backend/model/User.java
@@ -38,6 +38,9 @@ public class User {
     @Column(name = "requires_password_change")
     private boolean requiresPasswordChange;
 
+    @Column(name = "password_reset_token")
+    private String passwordResetToken;
+
     @Column(name = "current_advisee_count", nullable = false)
     private Integer currentAdviseeCount = 0;
 
@@ -54,6 +57,7 @@ public class User {
         this.role = other.role;
         this.createdAt = other.createdAt;
         this.requiresPasswordChange = other.requiresPasswordChange;
+        this.passwordResetToken = other.passwordResetToken;
         this.currentAdviseeCount = other.currentAdviseeCount;
     }
 
@@ -127,6 +131,14 @@ public class User {
 
     public void setRequiresPasswordChange(boolean requiresPasswordChange) {
         this.requiresPasswordChange = requiresPasswordChange;
+    }
+
+    public String getPasswordResetToken() {
+        return passwordResetToken;
+    }
+
+    public void setPasswordResetToken(String passwordResetToken) {
+        this.passwordResetToken = passwordResetToken;
     }
 
     public Integer getCurrentAdviseeCount() {

--- a/backend/src/main/java/com/spms/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/spms/backend/repository/UserRepository.java
@@ -16,6 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByGithubUsername(String githubUsername);
 
+    Optional<User> findByPasswordResetToken(String passwordResetToken);
+
     List<User> findAllByRoleIgnoreCase(String role);
 
     default boolean deleteByUserId(Long userId) {

--- a/backend/src/main/java/com/spms/backend/service/EmailService.java
+++ b/backend/src/main/java/com/spms/backend/service/EmailService.java
@@ -1,0 +1,126 @@
+package com.spms.backend.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import com.spms.backend.exception.EmailException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromAddress;
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
+    public EmailService(JavaMailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void sendPasswordResetEmail(String toEmail, String fullName, String resetToken) {
+        String resetUrl = frontendUrl + "/auth/reset-password?token=" + resetToken;
+
+        try {
+            MimeMessage mime = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mime, true, "UTF-8");
+            helper.setFrom(fromAddress);
+            helper.setTo(toEmail);
+            helper.setSubject("SPMS — Password Reset Request");
+            helper.setText(buildHtml(fullName, resetUrl), true);
+            mailSender.send(mime);
+        } catch (MessagingException e) {
+            throw new EmailException("Failed to send password reset email.", e);
+        }
+    }
+
+    private String buildHtml(String fullName, String resetUrl) {
+        return """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+              <meta charset="UTF-8"/>
+              <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+              <title>Password Reset</title>
+            </head>
+            <body style="margin:0;padding:0;background-color:#030712;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+              <table width="100%%" cellpadding="0" cellspacing="0" style="background-color:#030712;padding:48px 16px;">
+                <tr>
+                  <td align="center">
+
+                    <!-- Header -->
+                    <table width="480" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-bottom:32px;">
+                          <p style="margin:0;font-size:13px;font-weight:600;letter-spacing:0.15em;color:#6b7280;text-transform:uppercase;">
+                            Senior Project Management System
+                          </p>
+                          <div style="margin-top:8px;width:40px;height:2px;background-color:#2563eb;border-radius:2px;"></div>
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Card -->
+                    <table width="480" cellpadding="0" cellspacing="0"
+                           style="background-color:#111827;border:1px solid rgba(255,255,255,0.08);border-radius:16px;overflow:hidden;">
+                      <tr>
+                        <td style="padding:40px 40px 32px;">
+
+                          <p style="margin:0 0 8px;font-size:20px;font-weight:600;color:#f9fafb;text-align:center;">
+                            Password Reset Request
+                          </p>
+                          <p style="margin:0 0 28px;font-size:14px;color:#9ca3af;text-align:center;line-height:1.6;">
+                            Hello %s, we received a request to reset your password.<br/>
+                            Click the button below to set a new password for your account.
+                          </p>
+
+                          <!-- Button -->
+                          <table width="100%%" cellpadding="0" cellspacing="0">
+                            <tr>
+                              <td align="center" style="padding-bottom:28px;">
+                                <a href="%s"
+                                   style="display:inline-block;padding:14px 36px;background-color:#2563eb;color:#ffffff;
+                                          font-size:14px;font-weight:600;text-decoration:none;border-radius:10px;
+                                          letter-spacing:0.03em;">
+                                  SET NEW PASSWORD
+                                </a>
+                              </td>
+                            </tr>
+                          </table>
+
+                          <!-- Divider -->
+                          <div style="border-top:1px solid rgba(255,255,255,0.06);margin-bottom:24px;"></div>
+
+                          <p style="margin:0;font-size:12px;color:#6b7280;text-align:center;line-height:1.6;">
+                            This link can only be used once.<br/>
+                            If you did not request a password reset, you can safely ignore this email.
+                          </p>
+
+                        </td>
+                      </tr>
+                    </table>
+
+                    <!-- Footer -->
+                    <table width="480" cellpadding="0" cellspacing="0">
+                      <tr>
+                        <td align="center" style="padding-top:24px;">
+                          <p style="margin:0;font-size:11px;color:#374151;">
+                            Yaşar University &middot; Senior Project Management System
+                          </p>
+                        </td>
+                      </tr>
+                    </table>
+
+                  </td>
+                </tr>
+              </table>
+            </body>
+            </html>
+            """.formatted(fullName, resetUrl);
+    }
+}

--- a/backend/src/main/java/com/spms/backend/service/TokenService.java
+++ b/backend/src/main/java/com/spms/backend/service/TokenService.java
@@ -41,6 +41,7 @@ public class TokenService {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("sub", user.getUserId() != null ? user.getUserId().toString() : "");
         payload.put("userId", user.getUserId());
+        payload.put("email", user.getEmail());
         payload.put("studentId", user.getStudentId());
         payload.put("githubUsername", user.getGithubUsername());
         payload.put("role", user.getRole());

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -46,3 +46,18 @@ supabase:
   service-role-key: ${supabase.service-role-key}
   storage:
     bucket: ${supabase.storage.bucket:submissions}
+
+spring.mail:
+  host: smtp.gmail.com
+  port: 587
+  username: ${MAIL_USERNAME}
+  password: ${MAIL_PASSWORD}
+  properties:
+    mail:
+      smtp:
+        auth: true
+        starttls:
+          enable: true
+
+app:
+  frontend-url: ${FRONTEND_URL:http://localhost:3000}

--- a/backend/src/main/resources/db/migration/V23__Add_Password_Reset_Token_To_Users.sql
+++ b/backend/src/main/resources/db/migration/V23__Add_Password_Reset_Token_To_Users.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN IF NOT EXISTS password_reset_token VARCHAR(255);

--- a/backend/src/test/java/com/spms/backend/repository/InMemoryUserRepository.java
+++ b/backend/src/test/java/com/spms/backend/repository/InMemoryUserRepository.java
@@ -53,6 +53,15 @@ public class InMemoryUserRepository extends AbstractStubJpaRepository<User, Long
     }
 
     @Override
+    public Optional<User> findByPasswordResetToken(String passwordResetToken) {
+        if (!StringUtils.hasText(passwordResetToken)) return Optional.empty();
+        return usersById.values().stream()
+                .filter(u -> passwordResetToken.equals(u.getPasswordResetToken()))
+                .map(User::new)
+                .findFirst();
+    }
+
+    @Override
     public Optional<User> findByGithubUsername(String githubUsername) {
         String normalized = normalizeGithubUsername(githubUsername);
         if (normalized == null) return Optional.empty();

--- a/frontend/app/admin/reset-link/page.tsx
+++ b/frontend/app/admin/reset-link/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { getToken, getUser } from "@/lib/auth";
+import Sidebar from "@/components/Sidebar";
+
+export default function AdminResetLinkPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState({ type: "", text: "" });
+  const [isLoading, setIsLoading] = useState(false);
+  const [userRole, setUserRole] = useState<string | null>(null);
+
+  useEffect(() => {
+    const token = getToken();
+    const user = getUser();
+    if (!token || !user) { router.replace("/auth/login"); return; }
+    if (user.requiresPasswordChange) { router.replace("/auth/change-password"); return; }
+    if (user.role !== "coordinator") { router.replace("/dashboard"); return; }
+    setUserRole(user.role);
+  }, [router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage({ type: "", text: "" });
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setMessage({ type: "error", text: "Please enter a valid email address." });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const token = getToken();
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/admin/generate-reset-link`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ targetEmail: email }),
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (res.ok) {
+        setMessage({ type: "success", text: `Password reset email sent to ${email} successfully.` });
+        setEmail("");
+      } else {
+        setMessage({ type: "error", text: data.message || "Failed to send reset email. Check the email address." });
+      }
+    } catch {
+      setMessage({ type: "error", text: "Could not connect to the server." });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!userRole) return (
+    <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+      <svg className="w-6 h-6 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
+        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      </svg>
+    </div>
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-950 flex">
+      <Sidebar activePage="reset-link" />
+
+      <main className="flex-1 flex flex-col min-w-0">
+        <div className="border-b border-white/5 px-8 py-4 flex items-center justify-between">
+          <div>
+            <h1 className="text-base font-semibold text-white">Password Reset</h1>
+            <p className="text-xs text-gray-500 mt-0.5">Send a one-time password reset link to a professor</p>
+          </div>
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10">
+            <div className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+            <span className="text-xs text-gray-400">Online</span>
+          </div>
+        </div>
+
+        <div className="flex-1 p-8 flex items-start justify-center">
+          <div className="w-full max-w-md">
+            <div className="bg-gray-900 border border-white/8 rounded-2xl p-8 space-y-6">
+              <div className="space-y-1 text-center">
+                <h2 className="text-base font-semibold text-white">Send Reset Link</h2>
+                <span className="inline-block px-3 py-1 bg-blue-500/10 border border-blue-500/20 text-blue-400 text-xs font-medium rounded-full">
+                  Coordinator Access Only
+                </span>
+              </div>
+
+              <div className="px-4 py-3 rounded-xl bg-yellow-500/5 border border-yellow-500/20 text-yellow-400 text-xs flex items-start gap-2">
+                <svg className="w-4 h-4 shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                </svg>
+                The reset link can only be used once. The professor must have the application running locally to use it.
+              </div>
+
+              {message.text && (
+                <div className={[
+                  "px-4 py-3 rounded-xl text-xs font-medium flex items-center gap-2",
+                  message.type === "error"
+                    ? "bg-red-500/10 border border-red-500/20 text-red-400"
+                    : "bg-green-500/10 border border-green-500/20 text-green-400",
+                ].join(" ")}>
+                  <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    {message.type === "error" ? (
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                    ) : (
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                        d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    )}
+                  </svg>
+                  {message.text}
+                </div>
+              )}
+
+              <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+                <div className="space-y-1.5">
+                  <label htmlFor="email" className="text-xs font-medium text-gray-400">Professor Email</label>
+                  <input
+                    id="email"
+                    type="email"
+                    required
+                    placeholder="professor@yasar.edu.tr"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="w-full px-4 py-3 rounded-xl text-sm bg-white/5 border border-white/10 text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-colors"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  disabled={isLoading}
+                  className={[
+                    "w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-medium transition-all duration-150 mt-2",
+                    isLoading
+                      ? "bg-white/5 text-gray-600 cursor-not-allowed border border-white/5"
+                      : "bg-white text-gray-900 hover:bg-gray-100 active:scale-95 shadow-lg shadow-black/20",
+                  ].join(" ")}
+                >
+                  {isLoading ? (
+                    <>
+                      <svg className="w-4 h-4 animate-spin text-gray-500" fill="none" viewBox="0 0 24 24">
+                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                      </svg>
+                      <span className="text-gray-500">Sending...</span>
+                    </>
+                  ) : (
+                    "Send Reset Email"
+                  )}
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/app/auth/reset-password/page.tsx
+++ b/frontend/app/auth/reset-password/page.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+function ResetPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [formData, setFormData] = useState({ newPassword: "", confirmPassword: "" });
+  const [message, setMessage] = useState({ type: "", text: "" });
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      setMessage({ type: "error", text: "Invalid or missing reset token." });
+    }
+  }, [token]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage({ type: "", text: "" });
+
+    if (formData.newPassword !== formData.confirmPassword) {
+      setMessage({ type: "error", text: "Passwords do not match." });
+      return;
+    }
+
+    const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^\n]{8,}$/;
+    if (!passwordRegex.test(formData.newPassword)) {
+      setMessage({
+        type: "error",
+        text: "Password must be at least 8 characters, including uppercase, lowercase, and a number.",
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/auth/reset-password?token=${encodeURIComponent(token!)}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ newPassword: formData.newPassword }),
+        }
+      );
+
+      const data = await res.json().catch(() => ({}));
+
+      if (res.ok) {
+        setMessage({ type: "success", text: "Password updated successfully! Redirecting to login..." });
+        setTimeout(() => router.push("/auth/professor-login"), 2000);
+      } else {
+        setMessage({ type: "error", text: data.message || "Invalid or expired reset token." });
+      }
+    } catch {
+      setMessage({ type: "error", text: "Server connection failed. Please try again." });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-950 flex items-center justify-center px-4">
+      <div className="w-full max-w-sm space-y-8">
+        <div className="text-center space-y-3">
+          <div className="w-14 h-14 rounded-2xl bg-blue-600 flex items-center justify-center mx-auto shadow-lg shadow-blue-600/30">
+            <svg className="w-7 h-7 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+            </svg>
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold text-white">SPMS</h1>
+            <p className="text-sm text-gray-500">Senior Project Management System</p>
+          </div>
+        </div>
+
+        <div className="bg-gray-900 border border-white/8 rounded-2xl p-8 space-y-6">
+          <div className="space-y-1 text-center">
+            <h2 className="text-base font-semibold text-white">Set New Password</h2>
+            <p className="text-xs text-gray-500">Enter your new password below.</p>
+          </div>
+
+          {message.text && (
+            <div className={[
+              "px-4 py-3 rounded-xl text-xs font-medium flex items-center gap-2",
+              message.type === "error"
+                ? "bg-red-500/10 border border-red-500/20 text-red-400"
+                : "bg-green-500/10 border border-green-500/20 text-green-400",
+            ].join(" ")}>
+              <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                {message.type === "error" ? (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+                ) : (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+                    d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                )}
+              </svg>
+              {message.text}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+              <label htmlFor="newPassword" className="text-xs font-medium text-gray-400">New Password</label>
+              <input
+                id="newPassword"
+                type="password"
+                name="newPassword"
+                required
+                placeholder="••••••••"
+                value={formData.newPassword}
+                onChange={handleChange}
+                className="w-full px-4 py-3 rounded-xl text-sm bg-white/5 border border-white/10 text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-colors"
+              />
+              <p className="text-xs text-gray-600">At least 8 characters, 1 upper, 1 lower, 1 number.</p>
+            </div>
+
+            <div className="space-y-1.5">
+              <label htmlFor="confirmPassword" className="text-xs font-medium text-gray-400">Confirm Password</label>
+              <input
+                id="confirmPassword"
+                type="password"
+                name="confirmPassword"
+                required
+                placeholder="••••••••"
+                value={formData.confirmPassword}
+                onChange={handleChange}
+                className="w-full px-4 py-3 rounded-xl text-sm bg-white/5 border border-white/10 text-white placeholder-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-colors"
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={isLoading || !token}
+              className={[
+                "w-full flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-medium transition-all duration-150 mt-2",
+                isLoading || !token
+                  ? "bg-white/5 text-gray-600 cursor-not-allowed border border-white/5"
+                  : "bg-white text-gray-900 hover:bg-gray-100 active:scale-95 shadow-lg shadow-black/20",
+              ].join(" ")}
+            >
+              {isLoading ? (
+                <>
+                  <svg className="w-4 h-4 animate-spin text-gray-500" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                  </svg>
+                  <span className="text-gray-500">Updating...</span>
+                </>
+              ) : (
+                "Set New Password"
+              )}
+            </button>
+          </form>
+        </div>
+
+        <p className="text-center text-xs text-gray-700">
+          Yaşar University · Senior Project Management System
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense>
+      <ResetPasswordForm />
+    </Suspense>
+  );
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -55,7 +55,7 @@ export default function DashboardPage() {
           </div>
           <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10">
             <div className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
-            <span className="text-xs text-gray-400">Online</span>
+            <span className="text-xs text-gray-400">System Online</span>
           </div>
         </div>
 

--- a/frontend/app/professor/my-advisees/page.tsx
+++ b/frontend/app/professor/my-advisees/page.tsx
@@ -89,7 +89,7 @@ function MyAdviseesLayout() {
                     </div>
                     <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10">
                         <div className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
-                        <span className="text-xs text-gray-400">D2 Groups</span>
+                        <span className="text-xs text-gray-400">System Online</span>
                     </div>
                 </div>
                 <div className="flex-1 p-8">

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { getUser, clearAuth } from "@/lib/auth";
+import { getUser, clearAuth, getToken, decodeToken } from "@/lib/auth";
 
 export default function Sidebar({ activePage }: { activePage: string }) {
   const router = useRouter();
@@ -19,6 +19,9 @@ export default function Sidebar({ activePage }: { activePage: string }) {
   };
 
   if (!user) return <aside className="w-64 border-r border-white/5 bg-gray-950 shrink-0" />;
+
+  const decoded = decodeToken(getToken() ?? "");
+  const userEmail = decoded?.email as string | undefined;
 
   return (
     <aside className="w-64 border-r border-white/5 flex flex-col shrink-0 bg-gray-950">
@@ -232,7 +235,7 @@ export default function Sidebar({ activePage }: { activePage: string }) {
           </>
         )}
 
-        {(user.role === "coordinator" || user.role === "professor") && (
+        {user.role === "coordinator" && (
           <>
             <p className="text-xs font-medium text-gray-600 px-3 mt-4 mb-2 uppercase tracking-widest">Personnel</p>
             <NavItem
@@ -240,6 +243,12 @@ export default function Sidebar({ activePage }: { activePage: string }) {
               active={activePage === "register"}
               href="/admin/register"
               icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M19 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0z" /></svg>}
+            />
+            <NavItem
+              label="Password Reset"
+              active={activePage === "reset-link"}
+              href="/admin/reset-link"
+              icon={<svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25a3 3 0 013 3m3 0a6 6 0 01-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1121.75 8.25z" /></svg>}
             />
           </>
         )}
@@ -254,7 +263,9 @@ export default function Sidebar({ activePage }: { activePage: string }) {
           </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium text-white truncate capitalize">{user.role}</p>
-            {user.studentId && <p className="text-xs text-gray-500 truncate">{user.studentId}</p>}
+            {(user.studentId || userEmail) && (
+              <p className="text-xs text-gray-500 truncate">{user.studentId ?? userEmail}</p>
+            )}
           </div>
         </div>
         <button onClick={handleLogout} className="w-full mt-2 flex items-center gap-2 px-3 py-2 rounded-lg text-xs text-gray-500 hover:text-red-400 hover:bg-red-500/5 transition-colors">


### PR DESCRIPTION
## What does this PR do?

Implements the admin password reset via email feature. Adds a one-time password reset link system where coordinators can send a password reset email to a professor. Fixes the broken reset token design where the token was incorrectly stored in the `passwordHash` field. Also adds minor UI improvements including professor/coordinator email display in sidebar and "System Online" label.

## Changes

**Backend:**
- `V23 migration` — Adds `password_reset_token` column to users table
- `User` — Added `passwordResetToken` field with getter/setter
- `EmailService` — New service for sending HTML-formatted password reset emails via Gmail SMTP
- `EmailException` — New custom exception for email sending failures
- `AdminController` — Fixed reset token storage: token now written to `passwordResetToken` instead of overwriting `passwordHash`; triggers email send
- `AuthController` — Fixed reset-password endpoint to look up user by `passwordResetToken` field instead of scanning all users with hash comparison
- `UserRepository` — Added `findByPasswordResetToken` query method
- `TokenService` — Added `email` claim to JWT payload
- `InMemoryUserRepository` — Implemented `findByPasswordResetToken` for test compatibility
- `application.yml` — Added Gmail SMTP and `app.frontend-url` configuration

**Frontend:**
- `frontend/app/admin/reset-link/page.tsx` — New page for coordinator to send password reset emails
- `frontend/app/auth/reset-password/page.tsx` — New page for token-based password reset flow
- `Sidebar.tsx` — Shows professor/coordinator email at bottom; Personnel section restricted to coordinator only
- `dashboard/page.tsx`, `professor/my-advisees/page.tsx` — Updated "Online" label to "System Online"

## How it works

Coordinator navigates to Password Reset in sidebar, enters a professor's email, and clicks Send Reset Email. The backend generates a UUID token, stores it in the new `password_reset_token` column (leaving `password_hash` untouched), and sends an HTML email via Gmail SMTP. The professor clicks the link in the email which opens `/auth/reset-password?token=xxx` on their local frontend. After entering a valid new password, the token is nulled out, `requires_password_change` is set to false, and the professor is redirected to login.

## How to test
- [ ] Log in as Coordinator, navigate to Password Reset in sidebar
- [ ] Enter a registered professor email → success message shown, reset email received
- [ ] Click link in email → `/auth/reset-password` opens, enter new password → redirected to login
- [ ] Login with new password works
- [ ] Enter invalid/unregistered email → error message shown in English
- [ ] Enter malformed email → browser-native validation suppressed, our validation fires in English
- [ ] Professor sidebar no longer shows Personnel section
- [ ] Sidebar shows professor/coordinator email at bottom after login
