### PR TITLE
fix: allow professor role to list sprints

### DIFF
--- a/backend/src/main/java/com/spms/backend/controller/CoordinatorSprintController.java
+++ b/backend/src/main/java/com/spms/backend/controller/CoordinatorSprintController.java
@@ -28,7 +28,7 @@ public class CoordinatorSprintController {
     @Operation(summary = "List all sprints")
     @GetMapping
     public ResponseEntity<List<SprintDto>> getAllSprints(HttpServletRequest request) {
-        if (!isCoordinator(request)) return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        if (!isCoordinator(request) && !isProfessor(request)) return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         return ResponseEntity.ok(sprintService.getAllSprints());
     }
 
@@ -63,5 +63,9 @@ public class CoordinatorSprintController {
 
     private boolean isCoordinator(HttpServletRequest request) {
         return "coordinator".equals(request.getAttribute("jwt_role"));
+    }
+
+    private boolean isProfessor(HttpServletRequest request) {
+        return "professor".equals(request.getAttribute("jwt_role"));
     }
 }


### PR DESCRIPTION
## Summary

- `GET /api/v1/coordinator/sprints` returned 403 for professor role, causing the AI Validation sprints page to show "No sprints found." for professors
- Added `isProfessor` helper and allowed professor role on the list endpoint; write operations (POST/PUT/DELETE) remain coordinator-only
- Removed an empty stale `git` file from the repo root